### PR TITLE
Remove repositoryRootDirectory directory from IProjectStaticPredictor

### DIFF
--- a/documentation/design.md
+++ b/documentation/design.md
@@ -1,3 +1,5 @@
+**Note that this document was ported from the original implementation an may not completely match the current implementation**
+
 # Microsoft.Build.Prediction Design Notes
 MSBuildPrediction is loosely based on portions of a Microsoft-internal build engine that wraps MSBuild and provides build output caching and multi-machine distribution on top of [CloudBuild](https://www.microsoft.com/en-us/research/publication/cloudbuild-microsofts-distributed-and-caching-build-service/) to speed up builds especially for mid-to-large codebases. A particular component, EnlistmentLibrary or ENL for short, reads MSBuild files and outputs a dependency graph based on both ProjectReferences and predicting file and directory inputs and outputs and cross-comparing them to find dependencies. The file and directory inputs and outputs are then fed into caching algorithms to try to find cached build outputs.
 

--- a/src/BuildPrediction/IProjectStaticPredictor.cs
+++ b/src/BuildPrediction/IProjectStaticPredictor.cs
@@ -29,10 +29,6 @@ namespace Microsoft.Build.Prediction
         /// <param name="projectInstance">
         /// A <see cref="Microsoft.Build.Execution.ProjectInstance"/> derived from the the Project.
         /// </param>
-        /// <param name="repositoryRootDirectory">
-        /// The filesystem directory containing the source code of the repository. For Git submodules
-        /// this is typically the directory of the outermost containing repository.
-        /// </param>
         /// <param name="predictions">
         /// A <see cref="StaticPredictions"/> instance, whose collections can be empty. This value is allowed
         /// to be null which indicates an empty set result. This value should be null when returning false
@@ -48,7 +44,6 @@ namespace Microsoft.Build.Prediction
         bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions);
     }
 }

--- a/src/BuildPrediction/ProjectStaticPredictionExecutor.cs
+++ b/src/BuildPrediction/ProjectStaticPredictionExecutor.cs
@@ -17,38 +17,24 @@ namespace Microsoft.Build.Prediction
     /// </summary>
     public sealed class ProjectStaticPredictionExecutor
     {
-        private readonly string _repositoryRootDirectory;
         private readonly PredictorAndName[] _predictors;
         private readonly PredictionOptions _options;
 
         /// <summary>Initializes a new instance of the <see cref="ProjectStaticPredictionExecutor"/> class.</summary>
-        /// <param name="repositoryRootDirectory">
-        /// The filesystem directory containing the source code of the repository. For Git submodules
-        /// this is typically the directory of the outermost containing repository.
-        /// This is used for normalization of predicted paths.
-        /// </param>
         /// <param name="predictors">The set of <see cref="IProjectStaticPredictor"/> instances to use for prediction.</param>
         public ProjectStaticPredictionExecutor(
-            string repositoryRootDirectory,
             IEnumerable<IProjectStaticPredictor> predictors)
-            : this(repositoryRootDirectory, predictors, null)
+            : this(predictors, null)
         {
         }
 
         /// <summary>Initializes a new instance of the <see cref="ProjectStaticPredictionExecutor"/> class.</summary>
-        /// <param name="repositoryRootDirectory">
-        /// The filesystem directory containing the source code of the repository. For Git submodules
-        /// this is typically the directory of the outermost containing repository.
-        /// This is used for normalization of predicted paths.
-        /// </param>
         /// <param name="predictors">The set of <see cref="IProjectStaticPredictor"/> instances to use for prediction.</param>
         /// <param name="options">The options to use for prediction.</param>
         public ProjectStaticPredictionExecutor(
-            string repositoryRootDirectory,
             IEnumerable<IProjectStaticPredictor> predictors,
             PredictionOptions options)
         {
-            _repositoryRootDirectory = repositoryRootDirectory.ThrowIfNullOrEmpty(nameof(repositoryRootDirectory));
             _predictors = predictors
                 .ThrowIfNull(nameof(predictors))
                 .Select(p => new PredictorAndName(p))
@@ -133,7 +119,7 @@ namespace Microsoft.Build.Prediction
             return new StaticPredictions(inputsByPath.Values, outputDirectoriesByPath.Values);
         }
 
-        private void ExecuteSinglePredictor(
+        private static void ExecuteSinglePredictor(
             Project project,
             ProjectInstance projectInstance,
             PredictorAndName predictorAndName,
@@ -142,7 +128,6 @@ namespace Microsoft.Build.Prediction
             bool success = predictorAndName.Predictor.TryPredictInputsAndOutputs(
                 project,
                 projectInstance,
-                _repositoryRootDirectory,
                 out StaticPredictions result);
 
             // Tag each prediction with its source.

--- a/src/BuildPrediction/StandardPredictors/AvailableItemNameItems.cs
+++ b/src/BuildPrediction/StandardPredictors/AvailableItemNameItems.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions)
         {
             // TODO: Need to determine how to normalize evaluated include selected below and determine if it is relative to project.

--- a/src/BuildPrediction/StandardPredictors/CSharpCompileItems.cs
+++ b/src/BuildPrediction/StandardPredictors/CSharpCompileItems.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions)
         {
             // TODO: Need to determine how to normalize evaluated include selected below and determine if it is relative to project.

--- a/src/BuildPrediction/StandardPredictors/CopyTask/CopyTaskPredictor.cs
+++ b/src/BuildPrediction/StandardPredictors/CopyTask/CopyTaskPredictor.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions)
         {
             // Determine the active Targets in this Project.

--- a/src/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/StandardPredictors/IntermediateOutputPathIsOutputDir.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions)
         {
             string intermediateOutputPath = project.GetPropertyValue(IntermediateOutputPathMacro);

--- a/src/BuildPrediction/StandardPredictors/OutDirOrOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/StandardPredictors/OutDirOrOutputPathIsOutputDir.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            string repositoryRootDirectory,
             out StaticPredictions predictions)
         {
             string outDir = project.GetPropertyValue(OutDirMacro);

--- a/src/BuildPrediction/StandardPredictors/ProjectFileAndImportedFiles.cs
+++ b/src/BuildPrediction/StandardPredictors/ProjectFileAndImportedFiles.cs
@@ -13,7 +13,10 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     public class ProjectFileAndImportedFiles : IProjectStaticPredictor
     {
         /// <inheritdoc/>
-        public bool TryPredictInputsAndOutputs(Project project, ProjectInstance projectInstance, string repositoryRootDirectory, out StaticPredictions predictions)
+        public bool TryPredictInputsAndOutputs(
+            Project project,
+            ProjectInstance projectInstance,
+            out StaticPredictions predictions)
         {
             var inputs = new List<BuildInput>()
             {

--- a/src/BuildPredictionTests/ProjectStaticPredictionExecutorTests.cs
+++ b/src/BuildPredictionTests/ProjectStaticPredictionExecutorTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Prediction.Tests
                 new MockPredictor(new StaticPredictions(null, null)),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(@"c:\repo", predictors);
+            var executor = new ProjectStaticPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
             StaticPredictions predictions = executor.PredictInputsAndOutputs(project);
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Prediction.Tests
                     new[] { new BuildOutputDirectory(@"blah\boo2") })),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(@"c:\repo", predictors);
+            var executor = new ProjectStaticPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
 
@@ -77,7 +77,7 @@ namespace Microsoft.Build.Prediction.Tests
                     new[] { new BuildOutputDirectory(@"blah\boo") })),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(@"c:\repo", predictors);
+            var executor = new ProjectStaticPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
 
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Prediction.Tests
                             }
                         }
 
-                        var executor = new ProjectStaticPredictionExecutor(@"c:\repo", predictors);
+                        var executor = new ProjectStaticPredictionExecutor(predictors);
                         Stopwatch sw = Stopwatch.StartNew();
                         executor.PredictInputsAndOutputs(proj);
                         sw.Stop();
@@ -151,7 +151,6 @@ namespace Microsoft.Build.Prediction.Tests
             public bool TryPredictInputsAndOutputs(
                 Project project,
                 ProjectInstance projectInstance,
-                string repositoryRootDirectory,
                 out StaticPredictions predictions)
             {
                 if (_predictionsToReturn == null)

--- a/src/BuildPredictionTests/StandardPredictors/AvailableItemNameItemsTests.cs
+++ b/src/BuildPredictionTests/StandardPredictors/AvailableItemNameItemsTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
                 Tuple.Create("NotAvailable", "shouldNotGetThisAsAnInput"));
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new AvailableItemNameItems();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(
                 new[]

--- a/src/BuildPredictionTests/StandardPredictors/CSharpCompileItemsTests.cs
+++ b/src/BuildPredictionTests/StandardPredictors/CSharpCompileItemsTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject("Test.cs");
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new CSharpCompileItems();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(new[] { new BuildInput(Path.Combine(project.DirectoryPath, "Test.cs"), isDirectory: false) }, null);
         }

--- a/src/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
+++ b/src/BuildPredictionTests/StandardPredictors/IntermediateOutputPathIsOutputDirTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(IntermediateOutputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new IntermediateOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(IntermediateOutputPath) });
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(IntermediateOutputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new IntermediateOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(Path.Combine(Directory.GetCurrentDirectory(), IntermediateOutputPath)) });
         }
@@ -43,7 +43,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(null);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new IntermediateOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out _);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out _);
             Assert.False(hasPredictions, "Predictor should have fallen back to returning no predictions if IntermediateOutputDir is not defined in project");
         }
 

--- a/src/BuildPredictionTests/StandardPredictors/OutDirOrOutputPathIsOutputDirTests.cs
+++ b/src/BuildPredictionTests/StandardPredictors/OutDirOrOutputPathIsOutputDirTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(outDir, null);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new OutDirOrOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(outDir) });
         }
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(null, outputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new OutDirOrOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(outputPath) });
         }
@@ -41,7 +41,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(null, null);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new OutDirOrOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, @"C:\repo", out _);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out _);
             Assert.False(hasPredictions, "Predictor should have fallen back to returning no predictions if OutDir and OutputPath are not defined in project");
         }
 

--- a/src/BuildPredictionTests/TestBase.cs
+++ b/src/BuildPredictionTests/TestBase.cs
@@ -54,7 +54,6 @@ namespace Microsoft.Build.Prediction.Tests
             bool success = predictor.TryPredictInputsAndOutputs(
                 project,
                 projectInstance,
-                TestsDirectoryPath,
                 out StaticPredictions predictions);
 
             IReadOnlyCollection<BuildInput> absolutePathInputs = expectedInputs.Select(i =>


### PR DESCRIPTION
Currently no predictors use this.

The change in design will be that predictors should either return absolute or project-relative paths (which the "reporter" will normalize; this concept for a later change).

I anticipate quite a bit of churn as I muck around to get things ready for QuickBuild, so I'm going to defer on updating the design until the dust has settled.