### PR TITLE
Differentiate "basic" vs "all" predictors

### DIFF
--- a/src/BuildPrediction/ProjectStaticPredictors.cs
+++ b/src/BuildPrediction/ProjectStaticPredictors.cs
@@ -20,7 +20,6 @@ namespace Microsoft.Build.Prediction
         /// This includes the following predictors:
         /// <list type="bullet">
         /// <item><see cref="AvailableItemNameItems"/></item>
-        /// <item><see cref="CopyTaskPredictor"/></item>
         /// <item><see cref="CSharpCompileItems"/></item>
         /// <item><see cref="IntermediateOutputPathIsOutputDir"/></item>
         /// <item><see cref="OutDirOrOutputPathIsOutputDir"/></item>
@@ -31,11 +30,37 @@ namespace Microsoft.Build.Prediction
         public static IReadOnlyCollection<IProjectStaticPredictor> BasicPredictors => new IProjectStaticPredictor[]
         {
             new AvailableItemNameItems(),
+            new CSharpCompileItems(),
+            new IntermediateOutputPathIsOutputDir(),
+            new OutDirOrOutputPathIsOutputDir(),
+            new ProjectFileAndImportedFiles(),
+            //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
+        };
+
+        /// <summary>
+        /// Gets a collection of all <see cref="IProjectStaticPredictor"/>s. This is for convencience to avoid needing to specify all predictors explicitly.
+        /// </summary>
+        /// <remarks>
+        /// This includes the following predictors:
+        /// <list type="bullet">
+        /// <item><see cref="AvailableItemNameItems"/></item>
+        /// <item><see cref="CopyTaskPredictor"/></item>
+        /// <item><see cref="CSharpCompileItems"/></item>
+        /// <item><see cref="IntermediateOutputPathIsOutputDir"/></item>
+        /// <item><see cref="OutDirOrOutputPathIsOutputDir"/></item>
+        /// <item><see cref="ProjectFileAndImportedFiles"/></item>
+        /// </list>
+        /// </remarks>
+        /// <returns>A collection of <see cref="IProjectStaticPredictor"/>.</returns>
+        public static IReadOnlyCollection<IProjectStaticPredictor> AllPredictors => new IProjectStaticPredictor[]
+        {
+            new AvailableItemNameItems(),
             new CopyTaskPredictor(),
             new CSharpCompileItems(),
             new IntermediateOutputPathIsOutputDir(),
             new OutDirOrOutputPathIsOutputDir(),
             new ProjectFileAndImportedFiles(),
+            //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
         };
     }
 }

--- a/src/BuildPredictionTests/ProjectStaticPredictorsTests.cs
+++ b/src/BuildPredictionTests/ProjectStaticPredictorsTests.cs
@@ -16,6 +16,19 @@ namespace Microsoft.Build.Prediction.Tests
         {
             IReadOnlyCollection<IProjectStaticPredictor> predictors = ProjectStaticPredictors.BasicPredictors;
 
+            Assert.Equal(5, predictors.Count);
+            Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is AvailableItemNameItems));
+            Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is CSharpCompileItems));
+            Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is IntermediateOutputPathIsOutputDir));
+            Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is OutDirOrOutputPathIsOutputDir));
+            Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is ProjectFileAndImportedFiles));
+        }
+
+        [Fact]
+        public void AllPredictors()
+        {
+            IReadOnlyCollection<IProjectStaticPredictor> predictors = ProjectStaticPredictors.AllPredictors;
+
             Assert.Equal(6, predictors.Count);
             Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is AvailableItemNameItems));
             Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is CopyTaskPredictor));


### PR DESCRIPTION
The general intent is for "basic" predictors to be fast, and "all" predictors to be thorough.