### PR TITLE
Rename many classes and interfaces for brevity

### DIFF
--- a/src/BuildPrediction/BuildItem.cs
+++ b/src/BuildPrediction/BuildItem.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Build.Prediction
 
         /// <summary>
         /// Gets the class name of each contributor to this prediction, for debugging purposes.
-        /// These values are set in internally by <see cref="ProjectStaticPredictionExecutor"/>.
+        /// These values are set in internally by <see cref="ProjectPredictionExecutor"/>.
         /// </summary>
         public IReadOnlyCollection<string> PredictedBy => _predictedBy;
 

--- a/src/BuildPrediction/IProjectPredictor.cs
+++ b/src/BuildPrediction/IProjectPredictor.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Build.Prediction
     using Microsoft.Build.Execution;
 
     /// <summary>
-    /// Implementations of this interface are run in parallel against a single evaluated MSBuild Project
+    /// Implementations of this interface may be run in parallel against a single evaluated MSBuild Project
     /// file to predict, prior to execution of a build, file, directory/folder, and glob patterns for
     /// build inputs, and output directories written by the project.
     ///
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Prediction
     /// guidance to build execution sandboxing to allow better static analysis of the effects of
     /// executing the Project.
     /// </summary>
-    public interface IProjectStaticPredictor
+    public interface IProjectPredictor
     {
         /// <summary>
         /// Performs static prediction of build inputs and outputs for use by caching and sandboxing.
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Prediction
         /// A <see cref="Microsoft.Build.Execution.ProjectInstance"/> derived from the the Project.
         /// </param>
         /// <param name="predictions">
-        /// A <see cref="StaticPredictions"/> instance, whose collections can be empty. This value is allowed
+        /// A <see cref="ProjectPredictions"/> instance, whose collections can be empty. This value is allowed
         /// to be null which indicates an empty set result. This value should be null when returning false
         /// from this method.
         /// </param>
@@ -44,6 +44,6 @@ namespace Microsoft.Build.Prediction
         bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions);
+            out ProjectPredictions predictions);
     }
 }

--- a/src/BuildPrediction/Predictors/AvailableItemNameItems.cs
+++ b/src/BuildPrediction/Predictors/AvailableItemNameItems.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors
+namespace Microsoft.Build.Prediction.Predictors
 {
     using System;
     using System.Collections.Generic;
@@ -24,7 +24,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     ///
     /// Interestingly, C# Compile items have no AvailableItemName in their associated .targets file.
     /// </remarks>
-    public class AvailableItemNameItems : IProjectStaticPredictor
+    public class AvailableItemNameItems : IProjectPredictor
     {
         internal const string AvailableItemName = "AvailableItemName";
 
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             // TODO: Need to determine how to normalize evaluated include selected below and determine if it is relative to project.
             var availableItemNames = new HashSet<string>(
@@ -47,7 +47,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
                 .ToList();
             if (itemInputs.Count > 0)
             {
-                predictions = new StaticPredictions(itemInputs, null);
+                predictions = new ProjectPredictions(itemInputs, null);
                 return true;
             }
 

--- a/src/BuildPrediction/Predictors/CSharpCompileItems.cs
+++ b/src/BuildPrediction/Predictors/CSharpCompileItems.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors
+namespace Microsoft.Build.Prediction.Predictors
 {
     using System.Collections.Generic;
     using System.IO;
@@ -12,7 +12,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     /// <summary>
     /// Finds Compile items, typically but not necessarily always from csproj files, as inputs.
     /// </summary>
-    public class CSharpCompileItems : IProjectStaticPredictor
+    public class CSharpCompileItems : IProjectPredictor
     {
         internal const string CompileItemName = "Compile";
 
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             // TODO: Need to determine how to normalize evaluated include selected below and determine if it is relative to project.
             List<BuildInput> itemInputs = project.GetItems(CompileItemName)
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
                 .ToList();
             if (itemInputs.Count > 0)
             {
-                predictions = new StaticPredictions(itemInputs, buildOutputDirectories: null);
+                predictions = new ProjectPredictions(itemInputs, buildOutputDirectories: null);
                 return true;
             }
 

--- a/src/BuildPrediction/Predictors/CopyTask/CopyTaskPredictor.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/CopyTaskPredictor.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using System;
     using System.Collections.Generic;
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
     /// and follows the Targets activated by that target, along with all custom Targets
     /// present in the current project file.
     /// </remarks>
-    public class CopyTaskPredictor : IProjectStaticPredictor
+    public class CopyTaskPredictor : IProjectPredictor
     {
         private const string CopyTaskName = "Copy";
         private const string CopyTaskSourceFiles = "SourceFiles";
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             // Determine the active Targets in this Project.
             var activeTargets = new Dictionary<string, ProjectTargetInstance>(StringComparer.OrdinalIgnoreCase);
@@ -59,7 +59,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
 
             if (buildInputs.Count > 0)
             {
-                predictions = new StaticPredictions(
+                predictions = new ProjectPredictions(
                     buildInputs,
                     buildOutputDirectories.Select(o => new BuildOutputDirectory(o)).ToList());
                 return true;

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionBase.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionBase.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using System;
     using System.Collections.Generic;

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionBatched.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionBatched.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using System;
     using System.Text.RegularExpressions;

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionFactory.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionFactory.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using Microsoft.Build.Execution;
 

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionList.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionList.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using System.Collections.Generic;
     using System.Linq;

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionLiteral.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionLiteral.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using Microsoft.Build.Execution;
 

--- a/src/BuildPrediction/Predictors/CopyTask/FileExpressionTransform.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/FileExpressionTransform.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors.CopyTask
+namespace Microsoft.Build.Prediction.Predictors.CopyTask
 {
     using System;
     using Microsoft.Build.Execution;

--- a/src/BuildPrediction/Predictors/IntermediateOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/Predictors/IntermediateOutputPathIsOutputDir.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors
+namespace Microsoft.Build.Prediction.Predictors
 {
     using System.IO;
     using Microsoft.Build.Evaluation;
@@ -10,14 +10,14 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     /// <summary>
     /// Scrapes the $(IntermediateOutputPath) if found.
     /// </summary>
-    internal class IntermediateOutputPathIsOutputDir : IProjectStaticPredictor
+    internal class IntermediateOutputPathIsOutputDir : IProjectPredictor
     {
         internal const string IntermediateOutputPathMacro = "IntermediateOutputPath";
 
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             string intermediateOutputPath = project.GetPropertyValue(IntermediateOutputPathMacro);
 
@@ -39,7 +39,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
                 predictedOutputDirectory = intermediateOutputPath;
             }
 
-            predictions = new StaticPredictions(
+            predictions = new ProjectPredictions(
                 buildInputs: null,
                 buildOutputDirectories: new[] { new BuildOutputDirectory(Path.GetFullPath(predictedOutputDirectory)) });
             return true;

--- a/src/BuildPrediction/Predictors/OutDirOrOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/Predictors/OutDirOrOutputPathIsOutputDir.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors
+namespace Microsoft.Build.Prediction.Predictors
 {
     using System.IO;
     using Microsoft.Build.Evaluation;
@@ -10,7 +10,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     /// <summary>
     /// Scrapes the $(OutDir) or, if not found, $(OutputPath) as an output directory.
     /// </summary>
-    internal class OutDirOrOutputPathIsOutputDir : IProjectStaticPredictor
+    internal class OutDirOrOutputPathIsOutputDir : IProjectPredictor
     {
         internal const string OutDirMacro = "OutDir";
         internal const string OutputPathMacro = "OutputPath";
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             string outDir = project.GetPropertyValue(OutDirMacro);
             string outputPath = project.GetPropertyValue(OutputPathMacro);
@@ -55,7 +55,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
                 predictedOutputDirectory = finalOutputPath;
             }
 
-            predictions = new StaticPredictions(
+            predictions = new ProjectPredictions(
                 buildInputs: null,
                 buildOutputDirectories: new[] { new BuildOutputDirectory(Path.GetFullPath(predictedOutputDirectory)) });
             return true;

--- a/src/BuildPrediction/Predictors/ProjectFileAndImportedFiles.cs
+++ b/src/BuildPrediction/Predictors/ProjectFileAndImportedFiles.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.StandardPredictors
+namespace Microsoft.Build.Prediction.Predictors
 {
     using System.Collections.Generic;
     using Microsoft.Build.Evaluation;
@@ -10,13 +10,13 @@ namespace Microsoft.Build.Prediction.StandardPredictors
     /// <summary>
     /// Finds project filename and imports, as inputs.
     /// </summary>
-    public class ProjectFileAndImportedFiles : IProjectStaticPredictor
+    public class ProjectFileAndImportedFiles : IProjectPredictor
     {
         /// <inheritdoc/>
         public bool TryPredictInputsAndOutputs(
             Project project,
             ProjectInstance projectInstance,
-            out StaticPredictions predictions)
+            out ProjectPredictions predictions)
         {
             var inputs = new List<BuildInput>()
             {
@@ -28,7 +28,7 @@ namespace Microsoft.Build.Prediction.StandardPredictors
                 inputs.Add(new BuildInput(import.ImportedProject.FullPath, isDirectory: false));
             }
 
-            predictions = new StaticPredictions(inputs, null);
+            predictions = new ProjectPredictions(inputs, null);
 
             return true;
         }

--- a/src/BuildPrediction/ProjectPredictionOptions.cs
+++ b/src/BuildPrediction/ProjectPredictionOptions.cs
@@ -6,15 +6,15 @@ namespace Microsoft.Build.Prediction
     using System;
 
     /// <summary>
-    /// Represents various options used during prediction to change behavior.
+    /// Represents various options used during project prediction to change behavior.
     /// </summary>
-    public sealed class PredictionOptions
+    public sealed class ProjectPredictionOptions
     {
         /// <summary>
         /// Gets or sets the max degree of parallelism to use for prediction execution. Defaults to <see cref="Environment.ProcessorCount"/>.
         /// </summary>
         /// <remarks>
-        /// If the caller of <see cref="ProjectStaticPredictionExecutor"/> is parallelizing across projects, it's recommended to set this to 1 to avoid over-scheduling.
+        /// If the caller of <see cref="ProjectPredictionExecutor"/> is parallelizing across projects, it's recommended to set this to 1 to avoid over-scheduling.
         /// </remarks>
         public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
     }

--- a/src/BuildPrediction/ProjectPredictions.cs
+++ b/src/BuildPrediction/ProjectPredictions.cs
@@ -8,14 +8,14 @@ namespace Microsoft.Build.Prediction
 
     /// <summary>
     /// Predictions of build inputs and outputs provided by implementations of
-    /// <see cref="IProjectStaticPredictor"/>.
+    /// <see cref="IProjectPredictor"/>.
     /// </summary>
-    public sealed class StaticPredictions
+    public sealed class ProjectPredictions
     {
-        /// <summary>Initializes a new instance of the <see cref="StaticPredictions"/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref="ProjectPredictions"/> class.</summary>
         /// <param name="buildInputs">A collection of predicted file or directory inputs.</param>
         /// <param name="buildOutputDirectories">A collection of predicted directory outputs.</param>
-        public StaticPredictions(
+        public ProjectPredictions(
             IReadOnlyCollection<BuildInput> buildInputs,
             IReadOnlyCollection<BuildOutputDirectory> buildOutputDirectories)
         {

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -4,17 +4,17 @@
 namespace Microsoft.Build.Prediction
 {
     using System.Collections.Generic;
-    using Microsoft.Build.Prediction.StandardPredictors;
-    using Microsoft.Build.Prediction.StandardPredictors.CopyTask;
+    using Microsoft.Build.Prediction.Predictors;
+    using Microsoft.Build.Prediction.Predictors.CopyTask;
 
     /// <summary>
-    /// Creates instances of <see cref="IProjectStaticPredictor"/> for use with
-    /// <see cref="ProjectStaticPredictionExecutor"/>.
+    /// Creates instances of <see cref="IProjectPredictor"/> for use with
+    /// <see cref="ProjectPredictionExecutor"/>.
     /// </summary>
-    public static class ProjectStaticPredictors
+    public static class ProjectPredictors
     {
         /// <summary>
-        /// Gets a collection of all basic <see cref="IProjectStaticPredictor"/>s. This is for convencience to avoid needing to specify all basic predictors explicitly.
+        /// Gets a collection of all basic <see cref="IProjectPredictor"/>s. This is for convencience to avoid needing to specify all basic predictors explicitly.
         /// </summary>
         /// <remarks>
         /// This includes the following predictors:
@@ -26,8 +26,8 @@ namespace Microsoft.Build.Prediction
         /// <item><see cref="ProjectFileAndImportedFiles"/></item>
         /// </list>
         /// </remarks>
-        /// <returns>A collection of <see cref="IProjectStaticPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectStaticPredictor> BasicPredictors => new IProjectStaticPredictor[]
+        /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
+        public static IReadOnlyCollection<IProjectPredictor> BasicPredictors => new IProjectPredictor[]
         {
             new AvailableItemNameItems(),
             new CSharpCompileItems(),
@@ -38,7 +38,7 @@ namespace Microsoft.Build.Prediction
         };
 
         /// <summary>
-        /// Gets a collection of all <see cref="IProjectStaticPredictor"/>s. This is for convencience to avoid needing to specify all predictors explicitly.
+        /// Gets a collection of all <see cref="IProjectPredictor"/>s. This is for convencience to avoid needing to specify all predictors explicitly.
         /// </summary>
         /// <remarks>
         /// This includes the following predictors:
@@ -51,8 +51,8 @@ namespace Microsoft.Build.Prediction
         /// <item><see cref="ProjectFileAndImportedFiles"/></item>
         /// </list>
         /// </remarks>
-        /// <returns>A collection of <see cref="IProjectStaticPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectStaticPredictor> AllPredictors => new IProjectStaticPredictor[]
+        /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
+        public static IReadOnlyCollection<IProjectPredictor> AllPredictors => new IProjectPredictor[]
         {
             new AvailableItemNameItems(),
             new CopyTaskPredictor(),

--- a/src/BuildPredictionTests/Predictors/AvailableItemNameItemsTests.cs
+++ b/src/BuildPredictionTests/Predictors/AvailableItemNameItemsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using System;
     using System.Collections.Generic;
@@ -9,7 +9,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
     using Microsoft.Build.Construction;
     using Microsoft.Build.Evaluation;
     using Microsoft.Build.Execution;
-    using Microsoft.Build.Prediction.StandardPredictors;
+    using Microsoft.Build.Prediction.Predictors;
     using Xunit;
 
     // TODO: Need to add .NET Core and .NET Framework based examples including use of SDK includes.
@@ -26,7 +26,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
                 Tuple.Create("NotAvailable", "shouldNotGetThisAsAnInput"));
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new AvailableItemNameItems();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(
                 new[]

--- a/src/BuildPredictionTests/Predictors/CSharpCompileItemsTests.cs
+++ b/src/BuildPredictionTests/Predictors/CSharpCompileItemsTests.cs
@@ -1,13 +1,13 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using System.IO;
     using Microsoft.Build.Construction;
     using Microsoft.Build.Evaluation;
     using Microsoft.Build.Execution;
-    using Microsoft.Build.Prediction.StandardPredictors;
+    using Microsoft.Build.Prediction.Predictors;
     using Xunit;
 
     // TODO: Need to add .NET Core and .NET Framework based examples including use of SDK includes.
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject("Test.cs");
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new CSharpCompileItems();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(new[] { new BuildInput(Path.Combine(project.DirectoryPath, "Test.cs"), isDirectory: false) }, null);
         }

--- a/src/BuildPredictionTests/Predictors/CopyTaskPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/CopyTaskPredictorTests.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using System;
     using System.IO;
-    using Microsoft.Build.Prediction.StandardPredictors.CopyTask;
+    using Microsoft.Build.Prediction.Predictors.CopyTask;
     using Xunit;
 
     public class CopyTaskPredictorTests : TestBase

--- a/src/BuildPredictionTests/Predictors/IntermediateOutputPathIsOutputDirTests.cs
+++ b/src/BuildPredictionTests/Predictors/IntermediateOutputPathIsOutputDirTests.cs
@@ -1,14 +1,14 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using System.Collections.Generic;
     using System.IO;
     using Microsoft.Build.Construction;
     using Microsoft.Build.Evaluation;
     using Microsoft.Build.Execution;
-    using Microsoft.Build.Prediction.StandardPredictors;
+    using Microsoft.Build.Prediction.Predictors;
     using Xunit;
 
     public class IntermediateOutputPathIsOutputDirTests
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(IntermediateOutputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new IntermediateOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(IntermediateOutputPath) });
         }
@@ -32,7 +32,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(IntermediateOutputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new IntermediateOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(Path.Combine(Directory.GetCurrentDirectory(), IntermediateOutputPath)) });
         }

--- a/src/BuildPredictionTests/Predictors/OutDirOrOutputPathIsOutputDirTests.cs
+++ b/src/BuildPredictionTests/Predictors/OutDirOrOutputPathIsOutputDirTests.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using Microsoft.Build.Construction;
     using Microsoft.Build.Evaluation;
     using Microsoft.Build.Execution;
-    using Microsoft.Build.Prediction.StandardPredictors;
+    using Microsoft.Build.Prediction.Predictors;
     using Xunit;
 
     public class OutDirOrOutputPathIsOutputDirTests
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(outDir, null);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new OutDirOrOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(outDir) });
         }
@@ -30,7 +30,7 @@ namespace Microsoft.Build.Prediction.Tests.StandardPredictors
             Project project = CreateTestProject(null, outputPath);
             ProjectInstance projectInstance = project.CreateProjectInstance(ProjectInstanceSettings.ImmutableWithFastItemLookup);
             var predictor = new OutDirOrOutputPathIsOutputDir();
-            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out StaticPredictions predictions);
+            bool hasPredictions = predictor.TryPredictInputsAndOutputs(project, projectInstance, out ProjectPredictions predictions);
             Assert.True(hasPredictions);
             predictions.AssertPredictions(null, new[] { new BuildOutputDirectory(outputPath) });
         }

--- a/src/BuildPredictionTests/Predictors/ProjectFileAndImportedFilesTests.cs
+++ b/src/BuildPredictionTests/Predictors/ProjectFileAndImportedFilesTests.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Microsoft.Build.Prediction.Tests.StandardPredictors
+namespace Microsoft.Build.Prediction.Tests.Predictors
 {
     using System;
     using System.IO;
     using Microsoft.Build.Prediction;
-    using Microsoft.Build.Prediction.StandardPredictors;
+    using Microsoft.Build.Prediction.Predictors;
     using Microsoft.Build.Prediction.Tests;
     using Xunit;
 

--- a/src/BuildPredictionTests/ProjectPredictionExecutorTests.cs
+++ b/src/BuildPredictionTests/ProjectPredictionExecutorTests.cs
@@ -10,21 +10,21 @@ namespace Microsoft.Build.Prediction.Tests
     using Microsoft.Build.Execution;
     using Xunit;
 
-    public class ProjectStaticPredictionExecutorTests
+    public class ProjectPredictionExecutorTests
     {
         [Fact]
         public void EmptyPredictionsResultInEmptyAggregateResult()
         {
-            var predictors = new IProjectStaticPredictor[]
+            var predictors = new IProjectPredictor[]
             {
-                new MockPredictor(new StaticPredictions(null, null)),
-                new MockPredictor(new StaticPredictions(null, null)),
+                new MockPredictor(new ProjectPredictions(null, null)),
+                new MockPredictor(new ProjectPredictions(null, null)),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(predictors);
+            var executor = new ProjectPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
-            StaticPredictions predictions = executor.PredictInputsAndOutputs(project);
+            ProjectPredictions predictions = executor.PredictInputsAndOutputs(project);
             Assert.NotNull(predictions);
             Assert.Equal(0, predictions.BuildInputs.Count);
             Assert.Equal(0, predictions.BuildOutputDirectories.Count);
@@ -33,21 +33,21 @@ namespace Microsoft.Build.Prediction.Tests
         [Fact]
         public void DistinctInputsAndOutputsAreAggregated()
         {
-            var predictors = new IProjectStaticPredictor[]
+            var predictors = new IProjectPredictor[]
             {
-                new MockPredictor(new StaticPredictions(
+                new MockPredictor(new ProjectPredictions(
                     new[] { new BuildInput(@"foo\bar1", false) },
                     new[] { new BuildOutputDirectory(@"blah\boo1") })),
-                new MockPredictor2(new StaticPredictions(
+                new MockPredictor2(new ProjectPredictions(
                     new[] { new BuildInput(@"foo\bar2", false) },
                     new[] { new BuildOutputDirectory(@"blah\boo2") })),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(predictors);
+            var executor = new ProjectPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
 
-            StaticPredictions predictions = executor.PredictInputsAndOutputs(project);
+            ProjectPredictions predictions = executor.PredictInputsAndOutputs(project);
 
             BuildInput[] expectedInputs =
             {
@@ -67,21 +67,21 @@ namespace Microsoft.Build.Prediction.Tests
         [Fact]
         public void DuplicateInputsAndOutputsMergePredictedBys()
         {
-            var predictors = new IProjectStaticPredictor[]
+            var predictors = new IProjectPredictor[]
             {
-                new MockPredictor(new StaticPredictions(
+                new MockPredictor(new ProjectPredictions(
                     new[] { new BuildInput(@"foo\bar", false) },
                     new[] { new BuildOutputDirectory(@"blah\boo") })),
-                new MockPredictor2(new StaticPredictions(
+                new MockPredictor2(new ProjectPredictions(
                     new[] { new BuildInput(@"foo\bar", false) },
                     new[] { new BuildOutputDirectory(@"blah\boo") })),
             };
 
-            var executor = new ProjectStaticPredictionExecutor(predictors);
+            var executor = new ProjectPredictionExecutor(predictors);
 
             var project = TestHelpers.CreateProjectFromRootElement(ProjectRootElement.Create());
 
-            StaticPredictions predictions = executor.PredictInputsAndOutputs(project);
+            ProjectPredictions predictions = executor.PredictInputsAndOutputs(project);
 
             predictions.AssertPredictions(
                 new[] { new BuildInput(@"foo\bar", false, "MockPredictor", "MockPredictor2") },
@@ -104,7 +104,7 @@ namespace Microsoft.Build.Prediction.Tests
                 {
                     int numPredictors = numPredictorCases[p];
                     tickResults[p] = new long[sparsenessPercentages.Length];
-                    var predictors = new IProjectStaticPredictor[numPredictors];
+                    var predictors = new IProjectPredictor[numPredictors];
                     int sparseIndex = 0;
 
                     for (int s = 0; s < sparsenessPercentages.Length; s++)
@@ -118,7 +118,7 @@ namespace Microsoft.Build.Prediction.Tests
                             }
                             else
                             {
-                                predictors[i] = new MockPredictor(new StaticPredictions(null, null));
+                                predictors[i] = new MockPredictor(new ProjectPredictions(null, null));
                             }
 
                             sparseIndex++;
@@ -128,7 +128,7 @@ namespace Microsoft.Build.Prediction.Tests
                             }
                         }
 
-                        var executor = new ProjectStaticPredictionExecutor(predictors);
+                        var executor = new ProjectPredictionExecutor(predictors);
                         Stopwatch sw = Stopwatch.StartNew();
                         executor.PredictInputsAndOutputs(proj);
                         sw.Stop();
@@ -139,11 +139,11 @@ namespace Microsoft.Build.Prediction.Tests
             }
         }
 
-        private class MockPredictor : IProjectStaticPredictor
+        private class MockPredictor : IProjectPredictor
         {
-            private readonly StaticPredictions _predictionsToReturn;
+            private readonly ProjectPredictions _predictionsToReturn;
 
-            public MockPredictor(StaticPredictions predictionsToReturn)
+            public MockPredictor(ProjectPredictions predictionsToReturn)
             {
                 _predictionsToReturn = predictionsToReturn;
             }
@@ -151,7 +151,7 @@ namespace Microsoft.Build.Prediction.Tests
             public bool TryPredictInputsAndOutputs(
                 Project project,
                 ProjectInstance projectInstance,
-                out StaticPredictions predictions)
+                out ProjectPredictions predictions)
             {
                 if (_predictionsToReturn == null)
                 {
@@ -167,7 +167,7 @@ namespace Microsoft.Build.Prediction.Tests
         // Second class name to get different results from PredictedBy values.
         private class MockPredictor2 : MockPredictor
         {
-            public MockPredictor2(StaticPredictions predictionsToReturn)
+            public MockPredictor2(ProjectPredictions predictionsToReturn)
                 : base(predictionsToReturn)
             {
             }

--- a/src/BuildPredictionTests/ProjectPredictorsTests.cs
+++ b/src/BuildPredictionTests/ProjectPredictorsTests.cs
@@ -5,16 +5,16 @@ namespace Microsoft.Build.Prediction.Tests
 {
     using System.Collections.Generic;
     using System.Linq;
-    using Microsoft.Build.Prediction.StandardPredictors;
-    using Microsoft.Build.Prediction.StandardPredictors.CopyTask;
+    using Microsoft.Build.Prediction.Predictors;
+    using Microsoft.Build.Prediction.Predictors.CopyTask;
     using Xunit;
 
-    public class ProjectStaticPredictorsTests
+    public class ProjectPredictorsTests
     {
         [Fact]
         public void BasicPredictors()
         {
-            IReadOnlyCollection<IProjectStaticPredictor> predictors = ProjectStaticPredictors.BasicPredictors;
+            IReadOnlyCollection<IProjectPredictor> predictors = ProjectPredictors.BasicPredictors;
 
             Assert.Equal(5, predictors.Count);
             Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is AvailableItemNameItems));
@@ -27,7 +27,7 @@ namespace Microsoft.Build.Prediction.Tests
         [Fact]
         public void AllPredictors()
         {
-            IReadOnlyCollection<IProjectStaticPredictor> predictors = ProjectStaticPredictors.AllPredictors;
+            IReadOnlyCollection<IProjectPredictor> predictors = ProjectPredictors.AllPredictors;
 
             Assert.Equal(6, predictors.Count);
             Assert.NotNull(predictors.FirstOrDefault(predictor => predictor is AvailableItemNameItems));

--- a/src/BuildPredictionTests/TestBase.cs
+++ b/src/BuildPredictionTests/TestBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Build.Prediction.Tests
 
         protected void ParseAndVerifyProject(
             string projFileName,
-            IProjectStaticPredictor predictor,
+            IProjectPredictor predictor,
             IReadOnlyCollection<BuildInput> expectedInputs,
             IReadOnlyCollection<BuildOutputDirectory> expectedOutputs)
         {
@@ -54,7 +54,7 @@ namespace Microsoft.Build.Prediction.Tests
             bool success = predictor.TryPredictInputsAndOutputs(
                 project,
                 projectInstance,
-                out StaticPredictions predictions);
+                out ProjectPredictions predictions);
 
             IReadOnlyCollection<BuildInput> absolutePathInputs = expectedInputs.Select(i =>
                 new BuildInput(Path.Combine(project.DirectoryPath, i.Path), i.IsDirectory))

--- a/src/BuildPredictionTests/TestHelpers.cs
+++ b/src/BuildPredictionTests/TestHelpers.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Prediction.Tests
     internal static class TestHelpers
     {
         public static void AssertPredictions(
-            this StaticPredictions predictions,
+            this ProjectPredictions predictions,
             IReadOnlyCollection<BuildInput> expectedBuildInputs,
             IReadOnlyCollection<BuildOutputDirectory> expectedBuildOutputDirectories)
         {


### PR DESCRIPTION
I removed the word "Static" and "Standard" from most places, and prefixed most the "Predictor"/"Prediction" types with word "Project".