### PR TITLE
Add AzureCloudServiceWorkerFilesPredictor

### DIFF
--- a/src/BuildPrediction/Predictors/AzureCloudServiceWorkerFilesPredictor.cs
+++ b/src/BuildPrediction/Predictors/AzureCloudServiceWorkerFilesPredictor.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Predictors
+{
+    using System;
+    using System.IO;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.Build.Execution;
+
+    /// <summary>
+    /// Predicts inputs for Azure Cloud Service projects for the worker project files to be copied to the CS package.
+    /// </summary>
+    public class AzureCloudServiceWorkerFilesPredictor : IProjectPredictor
+    {
+        internal const string ProjectReferenceItemName = "ProjectReference";
+
+        internal const string AppConfigFileName = "app.config";
+
+        /// <inheritdoc/>
+        public void PredictInputsAndOutputs(
+            Project project,
+            ProjectInstance projectInstance,
+            ProjectPredictionReporter predictionReporter)
+        {
+            // This predictor only applies to ccproj files
+            if (!projectInstance.FullPath.EndsWith(".ccproj", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            /*
+                From Microsoft.WindowsAzure.targets in the CollectWorkerRoleFiles target:
+                    <MSBuild
+                      Projects="$(_WorkerRoleProject)"
+                      Targets="SourceFilesProjectOutputGroup"
+                      Properties="$(_WorkerRoleSetConfiguration);$(_WorkerRoleSetPlatform)"
+                      ContinueOnError="false">
+                      <Output TaskParameter="TargetOutputs" ItemName="SourceFilesOutputGroup" />
+                    </MSBuild>
+
+                    <!-- Add the app config file from SourceFilesOutputGroup -->
+                    <ItemGroup>
+                      <WorkerFiles Include="@(SourceFilesOutputGroup)" Condition=" '%(SourceFilesOutputGroup.TargetPath)' == '$(WorkerEntryPoint).config' " >
+                        <TargetPath>%(TargetPath)</TargetPath>
+                        <RoleOwner>$(_WorkerRoleProject)</RoleOwner>
+                        <RoleOwnerName>$(_WorkerRoleProjectName)</RoleOwnerName>
+                      </WorkerFiles>
+                    </ItemGroup>
+
+                Effectively, it just finds project references' app.config files to copy. Note that in theory the app.config can be already named <assembly-name>.config,
+                but this should be uncommon so for now this is a gap we're willing to live with.
+
+                TODO: There is a lot more logic adding WorkerFiles. However, they're generally all in the project reference's output directory or from nuget packages,
+                neither of which require as precise prediction. Perhaps when we have a better way to make predictions based on dependencies we can be more accurate here.
+            */
+            foreach (var projectReferenceItem in projectInstance.GetItems(ProjectReferenceItemName))
+            {
+                var projectReferenceRootDir = projectReferenceItem.GetMetadataValue("RootDir");
+                var projectReferenceDirectory = projectReferenceItem.GetMetadataValue("Directory");
+                var appConfigFile = projectReferenceRootDir + projectReferenceDirectory + AppConfigFileName;
+                if (File.Exists(appConfigFile))
+                {
+                    predictionReporter.ReportInputFile(appConfigFile);
+                }
+            }
+        }
+    }
+}

--- a/src/BuildPredictionTests/Predictors/AzureCloudServiceWorkerFilesPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/AzureCloudServiceWorkerFilesPredictorTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Tests.Predictors
+{
+    using System.IO;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.Build.Prediction.Predictors;
+    using Xunit;
+
+    public class AzureCloudServiceWorkerFilesPredictorTests
+    {
+        [Fact]
+        public void FindItems()
+        {
+            Project project = CreateTestProject("project.ccproj");
+            var expectedInputFiles = new[]
+            {
+                new PredictedItem($@"Worker1\{AzureCloudServiceWorkerFilesPredictor.AppConfigFileName}", nameof(AzureCloudServiceWorkerFilesPredictor)),
+                new PredictedItem($@"Worker2\{AzureCloudServiceWorkerFilesPredictor.AppConfigFileName}", nameof(AzureCloudServiceWorkerFilesPredictor)),
+            };
+            new AzureCloudServiceWorkerFilesPredictor()
+                .GetProjectPredictions(project)
+                .AssertPredictions(
+                    project,
+                    expectedInputFiles.MakeAbsolute(Directory.GetCurrentDirectory()),
+                    null,
+                    null,
+                    null);
+        }
+
+        [Fact]
+        public void SkipOtherProjectTypes()
+        {
+            Project project = CreateTestProject("project.csproj");
+            new AzureCloudServiceWorkerFilesPredictor()
+                .GetProjectPredictions(project)
+                .AssertNoPredictions();
+        }
+
+        private static Project CreateTestProject(string fileName)
+        {
+            ProjectRootElement projectRootElement = ProjectRootElement.Create($@"AzureCloudService\{fileName}");
+
+            ProjectItemGroupElement itemGroup = projectRootElement.AddItemGroup();
+            itemGroup.AddItem(AzureCloudServiceWorkerFilesPredictor.ProjectReferenceItemName, @"..\Worker1\Worker1.csproj");
+            itemGroup.AddItem(AzureCloudServiceWorkerFilesPredictor.ProjectReferenceItemName, @"..\Worker2\Worker2.csproj");
+            itemGroup.AddItem(AzureCloudServiceWorkerFilesPredictor.ProjectReferenceItemName, @"..\WorkerNoAppConfig\WorkerNoAppConfig.csproj");
+
+            // Add app.config files since existence is checked, but not for WorkerNoAppConfig
+            Directory.CreateDirectory(@"Worker1");
+            File.WriteAllText($@"Worker1\{AzureCloudServiceWorkerFilesPredictor.AppConfigFileName}", "SomeContent");
+            Directory.CreateDirectory(@"Worker2");
+            File.WriteAllText($@"Worker2\{AzureCloudServiceWorkerFilesPredictor.AppConfigFileName}", "SomeContent");
+
+            return TestHelpers.CreateProjectFromRootElement(projectRootElement);
+        }
+    }
+}


### PR DESCRIPTION
For now this just predicts app.config as it's the only `WorkerFiles` which isn't under the output dir or a nuget package. This should be augmented in the future.