### PR TITLE
Predictors should prefer using ProjectInstance over Project

### DIFF
--- a/src/BuildPrediction/Predictors/AvailableItemNameItems.cs
+++ b/src/BuildPrediction/Predictors/AvailableItemNameItems.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectPredictionReporter predictionReporter)
         {
             var availableItemNames = new HashSet<string>(
-                project.GetItems(AvailableItemName).Select(item => item.EvaluatedInclude),
+                projectInstance.GetItems(AvailableItemName).Select(item => item.EvaluatedInclude),
                 StringComparer.OrdinalIgnoreCase);
 
             foreach (string availableItemName in availableItemNames)

--- a/src/BuildPrediction/Predictors/AzureCloudServicePredictor.cs
+++ b/src/BuildPrediction/Predictors/AzureCloudServicePredictor.cs
@@ -28,12 +28,12 @@ namespace Microsoft.Build.Prediction.Predictors
                 return;
             }
 
-            foreach (ProjectItem item in project.GetItems(ServiceConfigurationItemName))
+            foreach (ProjectItemInstance item in projectInstance.GetItems(ServiceConfigurationItemName))
             {
                 predictionReporter.ReportInputFile(item.EvaluatedInclude);
             }
 
-            foreach (ProjectItem item in project.GetItems(ServiceDefinitionItemName))
+            foreach (ProjectItemInstance item in projectInstance.GetItems(ServiceDefinitionItemName))
             {
                 predictionReporter.ReportInputFile(item.EvaluatedInclude);
             }

--- a/src/BuildPrediction/Predictors/CSharpCompileItems.cs
+++ b/src/BuildPrediction/Predictors/CSharpCompileItems.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectInstance projectInstance,
             ProjectPredictionReporter predictionReporter)
         {
-            foreach (ProjectItem item in project.GetItems(CompileItemName))
+            foreach (ProjectItemInstance item in projectInstance.GetItems(CompileItemName))
             {
                 predictionReporter.ReportInputFile(item.EvaluatedInclude);
             }

--- a/src/BuildPrediction/Predictors/ContentItems.cs
+++ b/src/BuildPrediction/Predictors/ContentItems.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectInstance projectInstance,
             ProjectPredictionReporter predictionReporter)
         {
-            foreach (ProjectItem item in project.GetItems(ContentItemName))
+            foreach (ProjectItemInstance item in projectInstance.GetItems(ContentItemName))
             {
                 predictionReporter.ReportInputFile(item.EvaluatedInclude);
             }

--- a/src/BuildPrediction/Predictors/CopyTask/CopyTaskPredictor.cs
+++ b/src/BuildPrediction/Predictors/CopyTask/CopyTaskPredictor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Build.Prediction.Predictors.CopyTask
             // include custom targets defined directly in this Project.
             // Note that this misses targets defined in any custom targets files.
             foreach (ProjectTargetInstance target in projectInstance.Targets.Values
-                .Where(t => string.Equals(t.Location.File, project.ProjectFileLocation.File, PathComparer.Comparison)))
+                .Where(t => string.Equals(t.Location.File, projectInstance.ProjectFileLocation.File, PathComparer.Comparison)))
             {
                 project.AddToActiveTargets(new[] { target.Name }, activeTargets);
             }

--- a/src/BuildPrediction/Predictors/IntermediateOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/Predictors/IntermediateOutputPathIsOutputDir.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectInstance projectInstance,
             ProjectPredictionReporter predictionReporter)
         {
-            string intermediateOutputPath = project.GetPropertyValue(IntermediateOutputPathMacro);
+            string intermediateOutputPath = projectInstance.GetPropertyValue(IntermediateOutputPathMacro);
             if (!string.IsNullOrWhiteSpace(intermediateOutputPath))
             {
                 predictionReporter.ReportOutputDirectory(intermediateOutputPath);

--- a/src/BuildPrediction/Predictors/NoneItems.cs
+++ b/src/BuildPrediction/Predictors/NoneItems.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectInstance projectInstance,
             ProjectPredictionReporter predictionReporter)
         {
-            foreach (ProjectItem item in project.GetItems(NoneItemName))
+            foreach (ProjectItemInstance item in projectInstance.GetItems(NoneItemName))
             {
                 predictionReporter.ReportInputFile(item.EvaluatedInclude);
             }

--- a/src/BuildPrediction/Predictors/OutDirOrOutputPathIsOutputDir.cs
+++ b/src/BuildPrediction/Predictors/OutDirOrOutputPathIsOutputDir.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Prediction.Predictors
             // For an MSBuild project, the output goes to $(OutDir) by default. Usually $(OutDir)
             // equals $(OutputPath). Many targets expect OutputPath/OutDir to be defined and
             // MsBuild.exe reports an error if these macros are undefined.
-            string outDir = project.GetPropertyValue(OutDirMacro);
+            string outDir = projectInstance.GetPropertyValue(OutDirMacro);
             if (!string.IsNullOrWhiteSpace(outDir))
             {
                 predictionReporter.ReportOutputDirectory(outDir);
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Prediction.Predictors
             {
                 // Some projects use custom code with $(OutputPath) set instead of following the common .targets pattern.
                 // Fall back to $(OutputPath) first when $(OutDir) is not set.
-                string outputPath = project.GetPropertyValue(OutputPathMacro);
+                string outputPath = projectInstance.GetPropertyValue(OutputPathMacro);
                 if (!string.IsNullOrWhiteSpace(outputPath))
                 {
                     predictionReporter.ReportOutputDirectory(outputPath);

--- a/src/BuildPrediction/Predictors/ProjectFileAndImportedFiles.cs
+++ b/src/BuildPrediction/Predictors/ProjectFileAndImportedFiles.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.Prediction.Predictors
             ProjectInstance projectInstance,
             ProjectPredictionReporter predictionReporter)
         {
-            predictionReporter.ReportInputFile(project.FullPath);
+            predictionReporter.ReportInputFile(projectInstance.FullPath);
             foreach (ResolvedImport import in project.Imports)
             {
                 predictionReporter.ReportInputFile(import.ImportedProject.FullPath);


### PR DESCRIPTION
Some predictors still need Project, but everyone who can should use ProjectInstance.