### PR TITLE
Introduce graph predictions

### DIFF
--- a/src/BuildPrediction/DefaultProjectGraphPredictionCollector.cs
+++ b/src/BuildPrediction/DefaultProjectGraphPredictionCollector.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Build.Execution;
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// The default implementation which just aggregates all predictions into a <see cref="ProjectPredictions"/> object.
+    /// </summary>
+    internal sealed class DefaultProjectGraphPredictionCollector : IProjectPredictionCollector
+    {
+        private readonly Dictionary<ProjectInstance, DefaultProjectPredictionCollector> _collectorByProjectInstance;
+
+        public DefaultProjectGraphPredictionCollector(ProjectGraph projectGraph)
+        {
+            IReadOnlyCollection<ProjectGraphNode> projectGraphNodes = projectGraph.ProjectNodes;
+
+            var predictionsPerNode = new Dictionary<ProjectGraphNode, ProjectPredictions>(projectGraphNodes.Count);
+            GraphPredictions = new ProjectGraphPredictions(predictionsPerNode);
+
+            _collectorByProjectInstance = new Dictionary<ProjectInstance, DefaultProjectPredictionCollector>(projectGraphNodes.Count);
+            foreach (ProjectGraphNode projectGraphNode in projectGraphNodes)
+            {
+                var collector = new DefaultProjectPredictionCollector();
+                predictionsPerNode.Add(projectGraphNode, collector.Predictions);
+                _collectorByProjectInstance.Add(projectGraphNode.ProjectInstance, collector);
+            }
+        }
+
+        /// <summary>
+        /// Gets an aggregation of all predictions.
+        /// </summary>
+        internal ProjectGraphPredictions GraphPredictions { get; }
+
+        public void AddInputFile(string path, ProjectInstance projectInstance, string predictorName) => GetProjectCollector(projectInstance).AddInputFile(path, projectInstance, predictorName);
+
+        public void AddInputDirectory(string path, ProjectInstance projectInstance, string predictorName) => GetProjectCollector(projectInstance).AddInputDirectory(path, projectInstance, predictorName);
+
+        public void AddOutputFile(string path, ProjectInstance projectInstance, string predictorName) => GetProjectCollector(projectInstance).AddOutputFile(path, projectInstance, predictorName);
+
+        public void AddOutputDirectory(string path, ProjectInstance projectInstance, string predictorName) => GetProjectCollector(projectInstance).AddOutputDirectory(path, projectInstance, predictorName);
+
+        private DefaultProjectPredictionCollector GetProjectCollector(ProjectInstance projectInstance)
+        {
+            if (!_collectorByProjectInstance.TryGetValue(projectInstance, out DefaultProjectPredictionCollector collector))
+            {
+                throw new InvalidOperationException("Prediction collected for ProjectInstance not in the ProjectGraph");
+            }
+
+            return collector;
+        }
+    }
+}

--- a/src/BuildPrediction/IProjectGraphPredictor.cs
+++ b/src/BuildPrediction/IProjectGraphPredictor.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction
+{
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// Implementations of this interface may be run in parallel against a single evaluated MSBuild Project
+    /// file to predict, prior to execution of a build, file, directory/folder, and glob patterns for
+    /// build inputs, and output directories written by the project.
+    ///
+    /// The resulting inputs, if any, are intended to feed into build caching algorithms to provide an
+    /// initial hash for cache lookups. Inputs need not be 100% complete on a per-project basis, but
+    /// more accuracy and completeness leads to better cache performance.The output directories provide
+    /// guidance to build execution sandboxing to allow better static analysis of the effects of
+    /// executing the Project.
+    /// </summary>
+    public interface IProjectGraphPredictor
+    {
+        /// <summary>
+        /// Performs static prediction of build inputs and outputs for use by caching and sandboxing.
+        /// This method may be executing on multiple threads simultaneously and should act as a
+        /// pure method transforming its inputs into zero or more predictions in a thread-safe
+        /// and idempotent fashion.
+        /// </summary>
+        /// <param name="projectGraphNode">A <see cref="ProjectGraphNode"/> to use for predictions.</param>
+        /// <param name="predictionReporter">A reporter to report predictions to.</param>
+        /// <remarks>
+        /// Non-async since this should not require I/O, just CPU when examining the Project.
+        /// </remarks>
+        void PredictInputsAndOutputs(
+            ProjectGraphNode projectGraphNode,
+            ProjectPredictionReporter predictionReporter);
+    }
+}

--- a/src/BuildPrediction/IProjectPredictionCollector.cs
+++ b/src/BuildPrediction/IProjectPredictionCollector.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Build.Prediction
 {
+    using Microsoft.Build.Execution;
+
     /// <summary>
     /// Implementations of this interface are used during project prediction to
     /// collect all predictions from predictors.
@@ -13,32 +15,32 @@ namespace Microsoft.Build.Prediction
         /// Add a prediction for an input file.
         /// </summary>
         /// <param name="path">The path of the input file.</param>
-        /// <param name="projectDirectory">The path to the directory of the project prediction originated from, used for determining where the path might be relative to.</param>
+        /// <param name="projectInstance">The associated project instance for the prediction.</param>
         /// <param name="predictorName">The name of the predictor which made the prediction, used for debugging purposes.</param>
-        void AddInputFile(string path, string projectDirectory, string predictorName);
+        void AddInputFile(string path, ProjectInstance projectInstance, string predictorName);
 
         /// <summary>
         /// Add a prediction for an input directory. Implicitly this means the directory's contents, but not its subdirectories, are used as inputs. This is equivalent to a "*" glob.
         /// </summary>
         /// <param name="path">The path of the input directory.</param>
-        /// <param name="projectDirectory">The path to the directory of the project prediction originated from, used for determining where the path might be relative to.</param>
+        /// <param name="projectInstance">The associated project instance for the prediction.</param>
         /// <param name="predictorName">The name of the predictor which made the prediction, used for debugging purposes.</param>
-        void AddInputDirectory(string path, string projectDirectory, string predictorName);
+        void AddInputDirectory(string path, ProjectInstance projectInstance, string predictorName);
 
         /// <summary>
         /// Add a prediction for an output file.
         /// </summary>
         /// <param name="path">The path of the output file.</param>
-        /// <param name="projectDirectory">The path to the directory of the project prediction originated from, used for determining where the path might be relative to.</param>
+        /// <param name="projectInstance">The associated project instance for the prediction.</param>
         /// <param name="predictorName">The name of the predictor which made the prediction, used for debugging purposes.</param>
-        void AddOutputFile(string path, string projectDirectory, string predictorName);
+        void AddOutputFile(string path, ProjectInstance projectInstance, string predictorName);
 
         /// <summary>
         /// Add a prediction for an output directory.
         /// </summary>
         /// <param name="path">The path of the output directory.</param>
-        /// <param name="projectDirectory">The path to the directory of the project prediction originated from, used for determining where the path might be relative to.</param>
+        /// <param name="projectInstance">The associated project instance for the prediction.</param>
         /// <param name="predictorName">The name of the predictor which made the prediction, used for debugging purposes.</param>
-        void AddOutputDirectory(string path, string projectDirectory, string predictorName);
+        void AddOutputDirectory(string path, ProjectInstance projectInstance, string predictorName);
     }
 }

--- a/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Predictors
+{
+    using System;
+    using System.IO;
+    using Microsoft.Build.Execution;
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// Predicts files copied from dependencies in the GetCopyToOutputDirectoryItems.
+    /// </summary>
+    public sealed class GetCopyToOutputDirectoryItemsGraphPredictor : IProjectGraphPredictor
+    {
+        internal const string UseCommonOutputDirectoryPropertyName = "UseCommonOutputDirectory";
+        internal const string OutDirPropertyName = "OutDir";
+
+        /// <inheritdoc/>
+        public void PredictInputsAndOutputs(ProjectGraphNode projectGraphNode, ProjectPredictionReporter predictionReporter)
+        {
+            ProjectInstance projectInstance = projectGraphNode.ProjectInstance;
+
+            // The GetCopyToOutputDirectoryItems target gets called on all dependencies, unless UseCommonOutputDirectory is set to true.
+            var useCommonOutputDirectory = projectInstance.GetPropertyValue(UseCommonOutputDirectoryPropertyName);
+            if (!useCommonOutputDirectory.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                string outDir = projectInstance.GetPropertyValue(OutDirPropertyName);
+
+                // Note that GetCopyToOutputDirectoryItems effectively only is able to go one project reference deep despite being recursive as
+                // it uses @(_MSBuildProjectReferenceExistent) to recurse, which is not set in the recursive calls.
+                // See: https://github.com/microsoft/msbuild/blob/master/src/Tasks/Microsoft.Common.CurrentVersion.targets
+                foreach (ProjectGraphNode dependency in projectGraphNode.ProjectReferences)
+                {
+                    // Process each item type considered in GetCopyToOutputDirectoryItems. Yes, Compile is considered.
+                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, ContentItemsPredictor.ContentItemName, outDir, predictionReporter);
+                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, EmbeddedResourceItemsPredictor.EmbeddedResourceItemName, outDir, predictionReporter);
+                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, CompileItemsPredictor.CompileItemName, outDir, predictionReporter);
+                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, NoneItemsPredictor.NoneItemName, outDir, predictionReporter);
+
+                    // Process each item type considered in GetCopyToOutputDirectoryXamlAppDefs
+                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, XamlAppDefPredictor.XamlAppDefItemName, outDir, predictionReporter);
+                }
+            }
+        }
+
+        private static void ReportCopyToOutputDirectoryItemsAsInputs(
+            ProjectInstance projectInstance,
+            string itemName,
+            string outDir,
+            ProjectPredictionReporter predictionReporter)
+        {
+            foreach (ProjectItemInstance item in projectInstance.GetItems(itemName))
+            {
+                if (item.ShouldCopyToOutputDirectory())
+                {
+                    // The item will be relative to the project instance passed in, not the current project instance, so make the path absolute.
+                    predictionReporter.ReportInputFile(Path.Combine(projectInstance.Directory, item.EvaluatedInclude));
+
+                    if (!string.IsNullOrEmpty(outDir))
+                    {
+                        string targetPath = item.GetTargetPath();
+                        if (!string.IsNullOrEmpty(targetPath))
+                        {
+                            predictionReporter.ReportOutputFile(Path.Combine(outDir, targetPath));
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/BuildPrediction/Predictors/ProjectFileAndImportsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/ProjectFileAndImportsGraphPredictor.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Predictors
+{
+    using System.Collections.Generic;
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// Finds project filename and imports from transitive dependencies as inputs.
+    /// </summary>
+    public sealed class ProjectFileAndImportsGraphPredictor : IProjectGraphPredictor
+    {
+        /// <inheritdoc/>
+        public void PredictInputsAndOutputs(ProjectGraphNode projectGraphNode, ProjectPredictionReporter predictionReporter)
+        {
+            var seenGraphNodes = new HashSet<ProjectGraphNode>(projectGraphNode.ProjectReferences);
+            var graphNodesToProcess = new Queue<ProjectGraphNode>(projectGraphNode.ProjectReferences);
+            while (graphNodesToProcess.Count > 0)
+            {
+                ProjectGraphNode currentNode = graphNodesToProcess.Dequeue();
+
+                // Predict the project file itself and all its imports.
+                predictionReporter.ReportInputFile(currentNode.ProjectInstance.FullPath);
+                foreach (string import in currentNode.ProjectInstance.ImportPaths)
+                {
+                    predictionReporter.ReportInputFile(import);
+                }
+
+                // Recurse transitively
+                foreach (ProjectGraphNode projectReference in currentNode.ProjectReferences)
+                {
+                    if (seenGraphNodes.Add(projectReference))
+                    {
+                        graphNodesToProcess.Enqueue(projectReference);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/BuildPrediction/ProjectGraphPredictionExecutor.cs
+++ b/src/BuildPrediction/ProjectGraphPredictionExecutor.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Build.Definition;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.Build.Evaluation.Context;
+    using Microsoft.Build.Execution;
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// Executes a set of <see cref="IProjectPredictor"/> instances and <see cref="IProjectGraphPredictor"/>
+    /// instances against a project graph aggregating the results.
+    /// </summary>
+    public sealed class ProjectGraphPredictionExecutor
+    {
+        private readonly ValueAndTypeName<IProjectGraphPredictor>[] _projectGraphPredictors;
+        private readonly ValueAndTypeName<IProjectPredictor>[] _projectPredictors;
+        private readonly ProjectPredictionOptions _options;
+
+        /// <summary>Initializes a new instance of the <see cref="ProjectGraphPredictionExecutor"/> class.</summary>
+        /// <param name="projectGraphPredictors">The set of <see cref="IProjectGraphPredictor"/> instances to use for prediction.</param>
+        /// <param name="projectPredictors">The set of <see cref="IProjectPredictor"/> instances to use for prediction.</param>
+        public ProjectGraphPredictionExecutor(
+            IEnumerable<IProjectGraphPredictor> projectGraphPredictors,
+            IEnumerable<IProjectPredictor> projectPredictors)
+            : this(projectGraphPredictors, projectPredictors, null)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="ProjectGraphPredictionExecutor"/> class.</summary>
+        /// <param name="projectGraphPredictors">The set of <see cref="IProjectGraphPredictor"/> instances to use for prediction.</param>
+        /// <param name="projectPredictors">The set of <see cref="IProjectPredictor"/> instances to use for prediction.</param>
+        /// <param name="options">The options to use for prediction.</param>
+        public ProjectGraphPredictionExecutor(
+            IEnumerable<IProjectGraphPredictor> projectGraphPredictors,
+            IEnumerable<IProjectPredictor> projectPredictors,
+            ProjectPredictionOptions options)
+        {
+            _projectGraphPredictors = projectGraphPredictors
+                .ThrowIfNull(nameof(projectGraphPredictors))
+                .Select(p => new ValueAndTypeName<IProjectGraphPredictor>(p))
+                .ToArray(); // Array = faster parallel performance.
+            _projectPredictors = projectPredictors
+                .ThrowIfNull(nameof(projectPredictors))
+                .Select(p => new ValueAndTypeName<IProjectPredictor>(p))
+                .ToArray(); // Array = faster parallel performance.
+            _options = options ?? new ProjectPredictionOptions();
+        }
+
+        /// <summary>
+        /// Constructs a graph starting from the given graph entry points and execute all project and
+        /// graph predictors against the resulting projects.
+        /// </summary>
+        /// <param name="projectGraph">Project graph to run predictions on.</param>
+        /// <returns>An object describing all predicted inputs and outputs.</returns>
+        public ProjectGraphPredictions PredictInputsAndOutputs(ProjectGraph projectGraph)
+        {
+            var projectGraphPredictionCollector = new DefaultProjectGraphPredictionCollector(projectGraph);
+            PredictInputsAndOutputs(projectGraph, projectGraphPredictionCollector);
+            return projectGraphPredictionCollector.GraphPredictions;
+        }
+
+        /// <summary>
+        /// Constructs a graph starting from the given graph entry points and execute all project and
+        /// graph predictors against the resulting projects.
+        /// </summary>
+        /// <param name="projectGraph">Project graph to run predictions on.</param>
+        /// <param name="projectPredictionCollector">The prediction collector to use.</param>
+        public void PredictInputsAndOutputs(
+            ProjectGraph projectGraph,
+            IProjectPredictionCollector projectPredictionCollector)
+        {
+            projectGraph.ThrowIfNull(nameof(projectGraph));
+            projectPredictionCollector.ThrowIfNull(nameof(projectPredictionCollector));
+
+            // Special-case single-threaded prediction to avoid the overhead of Parallel.ForEach in favor of a simple loop.
+            if (_options.MaxDegreeOfParallelism == 1)
+            {
+                foreach (var projectNode in projectGraph.ProjectNodes)
+                {
+                    ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector);
+                }
+            }
+            else
+            {
+                Parallel.ForEach(
+                    projectGraph.ProjectNodes.ToArray(),
+                    new ParallelOptions() { MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism },
+                    projectNode => ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector));
+            }
+        }
+
+        private static void ExecuteAllPredictors(
+            ProjectGraphNode projectGraphNode,
+            ValueAndTypeName<IProjectPredictor>[] projectPredictors,
+            ValueAndTypeName<IProjectGraphPredictor>[] projectGraphPredictors,
+            IProjectPredictionCollector projectPredictionCollector)
+        {
+            ProjectInstance projectInstance = projectGraphNode.ProjectInstance;
+
+            // Run the project predictors. Use single-threaded prediction since we're already parallelizing on projects.
+            ProjectPredictionExecutor.ExecuteProjectPredictors(projectInstance, projectPredictors, projectPredictionCollector, maxDegreeOfParallelism: 1);
+
+            // Run the graph predictors
+            for (var i = 0; i < projectGraphPredictors.Length; i++)
+            {
+                var predictionReporter = new ProjectPredictionReporter(
+                    projectPredictionCollector,
+                    projectInstance,
+                    projectGraphPredictors[i].TypeName);
+
+                projectGraphPredictors[i].Value.PredictInputsAndOutputs(
+                    projectGraphNode,
+                    predictionReporter);
+            }
+        }
+    }
+}

--- a/src/BuildPrediction/ProjectGraphPredictions.cs
+++ b/src/BuildPrediction/ProjectGraphPredictions.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction
+{
+    using System.Collections.Generic;
+    using Microsoft.Build.Graph;
+
+    /// <summary>
+    /// Predictions of build inputs and outputs per graph node provided by implementations of
+    /// <see cref="IProjectGraphPredictor"/> and <see cref="IProjectPredictor"/>.
+    /// </summary>
+    public sealed class ProjectGraphPredictions
+    {
+        /// <summary>Initializes a new instance of the <see cref="ProjectGraphPredictions"/> class.</summary>
+        /// <param name="predictionsPerNode">The predictions for each graph node.</param>
+        public ProjectGraphPredictions(
+            IReadOnlyDictionary<ProjectGraphNode, ProjectPredictions> predictionsPerNode)
+        {
+            PredictionsPerNode = predictionsPerNode ?? new Dictionary<ProjectGraphNode, ProjectPredictions>(0);
+        }
+
+        /// <summary>Gets the predictions for each graph node.</summary>
+        public IReadOnlyDictionary<ProjectGraphNode, ProjectPredictions> PredictionsPerNode { get; }
+    }
+}

--- a/src/BuildPrediction/ProjectPredictionReporter.cs
+++ b/src/BuildPrediction/ProjectPredictionReporter.cs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Build.Prediction
 {
+    using Microsoft.Build.Execution;
+
     /// <summary>
     /// A reporter that <see cref="IProjectPredictor"/> instances use to report predictions.
     /// </summary>
@@ -17,7 +19,7 @@ namespace Microsoft.Build.Prediction
     {
         private readonly IProjectPredictionCollector _predictionCollector;
 
-        private readonly string _projectDirectory;
+        private readonly ProjectInstance _projectInstance;
 
         private readonly string _predictorName;
 
@@ -27,11 +29,11 @@ namespace Microsoft.Build.Prediction
         /// </remarks>
         internal ProjectPredictionReporter(
             IProjectPredictionCollector predictionCollector,
-            string projectDirectory,
+            ProjectInstance projectInstance,
             string predictorName)
         {
             _predictionCollector = predictionCollector;
-            _projectDirectory = projectDirectory;
+            _projectInstance = projectInstance;
             _predictorName = predictorName;
         }
 
@@ -39,24 +41,24 @@ namespace Microsoft.Build.Prediction
         /// Report a prediction for an input file.
         /// </summary>
         /// <param name="path">The path of the file input.</param>
-        public void ReportInputFile(string path) => _predictionCollector.AddInputFile(path, _projectDirectory, _predictorName);
+        public void ReportInputFile(string path) => _predictionCollector.AddInputFile(path, _projectInstance, _predictorName);
 
         /// <summary>
         /// Report a prediction for an input directory. Implicitly this means the directory's contents, but not its subdirectories, are used as inputs. This is equivalent to a "*" glob.
         /// </summary>
         /// <param name="path">The path of the file input.</param>
-        public void ReportInputDirectory(string path) => _predictionCollector.AddInputDirectory(path, _projectDirectory, _predictorName);
+        public void ReportInputDirectory(string path) => _predictionCollector.AddInputDirectory(path, _projectInstance, _predictorName);
 
         /// <summary>
         /// Report a prediction for an output file.
         /// </summary>
         /// <param name="path">The path of the directory output.</param>
-        public void ReportOutputFile(string path) => _predictionCollector.AddOutputFile(path, _projectDirectory, _predictorName);
+        public void ReportOutputFile(string path) => _predictionCollector.AddOutputFile(path, _projectInstance, _predictorName);
 
         /// <summary>
         /// Report a prediction for an output directory.
         /// </summary>
         /// <param name="path">The path of the directory output.</param>
-        public void ReportOutputDirectory(string path) => _predictionCollector.AddOutputDirectory(path, _projectDirectory, _predictorName);
+        public void ReportOutputDirectory(string path) => _predictionCollector.AddOutputDirectory(path, _projectInstance, _predictorName);
     }
 }

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -14,82 +14,6 @@ namespace Microsoft.Build.Prediction
     public static class ProjectPredictors
     {
         /// <summary>
-        /// Gets a collection of all basic <see cref="IProjectPredictor"/>s. This is for convencience to avoid needing to specify all basic predictors explicitly.
-        /// </summary>
-        /// <remarks>
-        /// This includes the following predictors:
-        /// <list type="bullet">
-        /// <item><see cref="AvailableItemNameItemsPredictor"/></item>
-        /// <item><see cref="ContentItemsPredictor"/></item>
-        /// <item><see cref="NoneItemsPredictor"/></item>
-        /// <item><see cref="CompileItemsPredictor"/></item>
-        /// <item><see cref="IntermediateOutputPathPredictor"/></item>
-        /// <item><see cref="OutDirOrOutputPathPredictor"/></item>
-        /// <item><see cref="ProjectFileAndImportsPredictor"/></item>
-        /// <item><see cref="AzureCloudServicePredictor"/></item>
-        /// <item><see cref="ServiceFabricServiceManifestPredictor"/></item>
-        /// <item><see cref="AzureCloudServiceWorkerFilesPredictor"/></item>
-        /// <item><see cref="CodeAnalysisRuleSetPredictor"/></item>
-        /// <item><see cref="AssemblyOriginatorKeyFilePredictor"/></item>
-        /// <item><see cref="EmbeddedResourceItemsPredictor"/></item>
-        /// <item><see cref="ReferenceItemsPredictor"/></item>
-        /// <item><see cref="StyleCopPredictor"/></item>
-        /// <item><see cref="ManifestsPredictor"/></item>
-        /// <item><see cref="VSCTCompileItemsPredictor"/></item>
-        /// <item><see cref="EditorConfigFilesItemsPredictor"/></item>
-        /// <item><see cref="ApplicationIconPredictor"/></item>
-        /// <item><see cref="GeneratePackageOnBuildPredictor"/></item>
-        /// <item><see cref="CompiledAssemblyPredictor"/></item>
-        /// <item><see cref="DocumentationFilePredictor"/></item>
-        /// <item><see cref="RefAssemblyPredictor"/></item>
-        /// <item><see cref="SymbolsFilePredictor"/></item>
-        /// <item><see cref="XamlAppDefPredictor"/></item>
-        /// <item><see cref="TypeScriptCompileItemsPredictor"/></item>
-        /// <item><see cref="ApplicationDefinitionItemsPredictor"/></item>
-        /// <item><see cref="PageItemsPredictor"/></item>
-        /// <item><see cref="ResourceItemsPredictor"/></item>
-        /// <item><see cref="SplashScreenItemsPredictor"/></item>
-        /// <item><see cref="TsConfigPredictor"/></item>
-        /// </list>
-        /// </remarks>
-        /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectPredictor> BasicPredictors => new IProjectPredictor[]
-        {
-            new AvailableItemNameItemsPredictor(),
-            new ContentItemsPredictor(),
-            new NoneItemsPredictor(),
-            new CompileItemsPredictor(),
-            new IntermediateOutputPathPredictor(),
-            new OutDirOrOutputPathPredictor(),
-            new ProjectFileAndImportsPredictor(),
-            new AzureCloudServicePredictor(),
-            new ServiceFabricServiceManifestPredictor(),
-            new AzureCloudServiceWorkerFilesPredictor(),
-            new CodeAnalysisRuleSetPredictor(),
-            new AssemblyOriginatorKeyFilePredictor(),
-            new EmbeddedResourceItemsPredictor(),
-            new ReferenceItemsPredictor(),
-            new StyleCopPredictor(),
-            new ManifestsPredictor(),
-            new VSCTCompileItemsPredictor(),
-            new EditorConfigFilesItemsPredictor(),
-            new ApplicationIconPredictor(),
-            new GeneratePackageOnBuildPredictor(),
-            new CompiledAssemblyPredictor(),
-            new DocumentationFilePredictor(),
-            new RefAssemblyPredictor(),
-            new SymbolsFilePredictor(),
-            new XamlAppDefPredictor(),
-            new TypeScriptCompileItemsPredictor(),
-            new ApplicationDefinitionItemsPredictor(),
-            new PageItemsPredictor(),
-            new ResourceItemsPredictor(),
-            new SplashScreenItemsPredictor(),
-            new TsConfigPredictor(),
-            //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
-        };
-
-        /// <summary>
         /// Gets a collection of all <see cref="IProjectPredictor"/>s. This is for convencience to avoid needing to specify all predictors explicitly.
         /// </summary>
         /// <remarks>
@@ -131,7 +55,7 @@ namespace Microsoft.Build.Prediction
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectPredictor> AllPredictors => new IProjectPredictor[]
+        public static IReadOnlyCollection<IProjectPredictor> AllProjectPredictors => new IProjectPredictor[]
         {
             new AvailableItemNameItemsPredictor(),
             new ContentItemsPredictor(),
@@ -166,6 +90,24 @@ namespace Microsoft.Build.Prediction
             new ResourceItemsPredictor(),
             new SplashScreenItemsPredictor(),
             new TsConfigPredictor(),
+            //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
+        };
+
+        /// <summary>
+        /// Gets a collection of all <see cref="IProjectGraphPredictor"/>s. This is for convencience to avoid needing to specify all graph predictors explicitly.
+        /// </summary>
+        /// <remarks>
+        /// This includes the following graph predictors:
+        /// <list type="bullet">
+        /// <item><see cref="ProjectFileAndImportsGraphPredictor"/></item>
+        /// <item><see cref="GetCopyToOutputDirectoryItemsGraphPredictor"/></item>
+        /// </list>
+        /// </remarks>
+        /// <returns>A collection of <see cref="IProjectGraphPredictor"/>.</returns>
+        public static IReadOnlyCollection<IProjectGraphPredictor> AllProjectGraphPredictors => new IProjectGraphPredictor[]
+        {
+            new ProjectFileAndImportsGraphPredictor(),
+            new GetCopyToOutputDirectoryItemsGraphPredictor(),
             //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
         };
     }

--- a/src/BuildPrediction/ValueAndTypeName.cs
+++ b/src/BuildPrediction/ValueAndTypeName.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction
+{
+    internal readonly struct ValueAndTypeName<T>
+    {
+        public readonly T Value;
+
+        /// <summary>
+        /// Cached type name - we expect object instances to be reused many times in
+        /// an overall execution, avoid doing the reflection over and over in
+        /// to get the type name.
+        /// </summary>
+        public readonly string TypeName;
+
+        public ValueAndTypeName(T value)
+        {
+            Value = value;
+            TypeName = value.GetType().Name;
+        }
+    }
+}

--- a/src/BuildPredictionTests/Predictors/GetCopyToOutputDirectoryItemsGraphPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/GetCopyToOutputDirectoryItemsGraphPredictorTests.cs
@@ -1,0 +1,168 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Tests.Predictors
+{
+    using System;
+    using System.IO;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Prediction.Predictors;
+    using Xunit;
+
+    public class GetCopyToOutputDirectoryItemsGraphPredictorTests
+    {
+        private readonly string _rootDir;
+
+        public GetCopyToOutputDirectoryItemsGraphPredictorTests()
+        {
+            // Isolate each test into its own folder
+            _rootDir = Path.Combine(Directory.GetCurrentDirectory(), nameof(ArtifactsSdkPredictorTests), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_rootDir);
+        }
+
+        [Fact]
+        public void NoCopy()
+        {
+            string projectFile = Path.Combine(_rootDir, @"src\project.csproj");
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(projectFile);
+            projectRootElement.AddProperty(ContentItemsPredictor.OutDirPropertyName, @"bin\");
+
+            const bool shouldCopy = false;
+            ProjectRootElement dep1 = CreateDependencyProject("dep1", shouldCopy);
+            ProjectRootElement dep2 = CreateDependencyProject("dep2", shouldCopy);
+            ProjectRootElement dep3 = CreateDependencyProject("dep3", shouldCopy);
+
+            // The main project depends on 1 and 2; 2 depends on 3; 3 depends on 1. Note that this predictor should *not* be transitive
+            projectRootElement.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+            projectRootElement.AddItem("ProjectReference", @"..\dep2\dep2.proj");
+            dep2.AddItem("ProjectReference", @"..\dep3\dep3.proj");
+            dep3.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+
+            projectRootElement.Save();
+            dep1.Save();
+            dep2.Save();
+            dep3.Save();
+
+            new GetCopyToOutputDirectoryItemsGraphPredictor()
+                .GetProjectPredictions(projectFile)
+                .AssertNoPredictions();
+        }
+
+        [Fact]
+        public void UseCommonOutputDirectory()
+        {
+            string projectFile = Path.Combine(_rootDir, @"src\project.csproj");
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(projectFile);
+            projectRootElement.AddProperty(GetCopyToOutputDirectoryItemsGraphPredictor.OutDirPropertyName, @"bin\");
+            projectRootElement.AddProperty(GetCopyToOutputDirectoryItemsGraphPredictor.UseCommonOutputDirectoryPropertyName, "true");
+
+            const bool shouldCopy = true;
+            ProjectRootElement dep1 = CreateDependencyProject("dep1", shouldCopy);
+            ProjectRootElement dep2 = CreateDependencyProject("dep2", shouldCopy);
+            ProjectRootElement dep3 = CreateDependencyProject("dep3", shouldCopy);
+
+            // The main project depends on 1 and 2; 2 depends on 3; 3 depends on 1. Note that this predictor should *not* be transitive
+            projectRootElement.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+            projectRootElement.AddItem("ProjectReference", @"..\dep2\dep2.proj");
+            dep2.AddItem("ProjectReference", @"..\dep3\dep3.proj");
+            dep3.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+
+            projectRootElement.Save();
+            dep1.Save();
+            dep2.Save();
+            dep3.Save();
+
+            new GetCopyToOutputDirectoryItemsGraphPredictor()
+                .GetProjectPredictions(projectFile)
+                .AssertNoPredictions();
+        }
+
+        [Fact]
+        public void WithCopy()
+        {
+            string projectFile = Path.Combine(_rootDir, @"src\project.csproj");
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(projectFile);
+            projectRootElement.AddProperty(GetCopyToOutputDirectoryItemsGraphPredictor.OutDirPropertyName, @"bin\");
+
+            const bool shouldCopy = true;
+            ProjectRootElement dep1 = CreateDependencyProject("dep1", shouldCopy);
+            ProjectRootElement dep2 = CreateDependencyProject("dep2", shouldCopy);
+            ProjectRootElement dep3 = CreateDependencyProject("dep3", shouldCopy);
+
+            // The main project depends on 1 and 2; 2 depends on 3; 3 depends on 1. Note that this should *not* be transitive
+            projectRootElement.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+            projectRootElement.AddItem("ProjectReference", @"..\dep2\dep2.proj");
+            dep2.AddItem("ProjectReference", @"..\dep3\dep3.proj");
+            dep3.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+
+            projectRootElement.Save();
+            dep1.Save();
+            dep2.Save();
+            dep3.Save();
+
+            var expectedInputFiles = new[]
+            {
+                new PredictedItem(@"dep1\dep1.xml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep1\dep1.resx", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep1\dep1.cs", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep1\dep1.txt", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep1\dep1.xaml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.xml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.resx", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.cs", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.txt", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.xaml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+            };
+
+            var expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"src\bin\dep1.xml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep1.resx", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep1.cs", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep1.txt", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep1.xaml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep2.xml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep2.resx", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep2.cs", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep2.txt", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+                new PredictedItem(@"src\bin\dep2.xaml", nameof(GetCopyToOutputDirectoryItemsGraphPredictor)),
+            };
+
+            new GetCopyToOutputDirectoryItemsGraphPredictor()
+                .GetProjectPredictions(projectFile)
+                .AssertPredictions(
+                    _rootDir,
+                    expectedInputFiles,
+                    null,
+                    expectedOutputFiles,
+                    null);
+        }
+
+        private ProjectRootElement CreateDependencyProject(string projectName, bool shouldCopy)
+        {
+            string projectDir = Path.Combine(_rootDir, projectName);
+            Directory.CreateDirectory(projectDir);
+
+            string projectFileName = projectName + ".proj";
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(projectDir, projectFileName));
+
+            ProjectItemElement contentItem = projectRootElement.AddItem(ContentItemsPredictor.ContentItemName, projectName + ".xml");
+            ProjectItemElement embeddedResourceItem = projectRootElement.AddItem(EmbeddedResourceItemsPredictor.EmbeddedResourceItemName, projectName + ".resx");
+            ProjectItemElement compileItem = projectRootElement.AddItem(CompileItemsPredictor.CompileItemName, projectName + ".cs");
+            ProjectItemElement noneItem = projectRootElement.AddItem(NoneItemsPredictor.NoneItemName, projectName + ".txt");
+            ProjectItemElement xamlAppDefItem = projectRootElement.AddItem(XamlAppDefPredictor.XamlAppDefItemName, projectName + ".xaml");
+
+            if (shouldCopy)
+            {
+                contentItem.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+                embeddedResourceItem.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+                compileItem.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+                noneItem.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+                xamlAppDefItem.AddMetadata("CopyToOutputDirectory", "PreserveNewest");
+            }
+
+            // The caller may modify the returned project, so don't save it yet.
+            return projectRootElement;
+        }
+    }
+}

--- a/src/BuildPredictionTests/Predictors/ProjectFileAndImportsGraphPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/ProjectFileAndImportsGraphPredictorTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Tests.Predictors
+{
+    using System;
+    using System.IO;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Prediction.Predictors;
+    using Xunit;
+
+    public class ProjectFileAndImportsGraphPredictorTests
+    {
+        private readonly string _rootDir;
+
+        public ProjectFileAndImportsGraphPredictorTests()
+        {
+            // Isolate each test into its own folder
+            _rootDir = Path.Combine(Directory.GetCurrentDirectory(), nameof(ArtifactsSdkPredictorTests), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_rootDir);
+        }
+
+        [Fact]
+        public void FindItems()
+        {
+            string projectFile = Path.Combine(_rootDir, @"src\project.csproj");
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(projectFile);
+
+            ProjectRootElement dep1 = CreateDependencyProject("dep1");
+            ProjectRootElement dep2 = CreateDependencyProject("dep2");
+            ProjectRootElement dep3 = CreateDependencyProject("dep3");
+            ProjectRootElement dep4 = CreateDependencyProject("dep4");
+
+            // The main project depends on 1 and 2; 2 depends on 3; 3 depends on 1 and 4.
+            // This tests both transitivity and deduping.
+            projectRootElement.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+            projectRootElement.AddItem("ProjectReference", @"..\dep2\dep2.proj");
+            dep2.AddItem("ProjectReference", @"..\dep3\dep3.proj");
+            dep3.AddItem("ProjectReference", @"..\dep1\dep1.proj");
+            dep3.AddItem("ProjectReference", @"..\dep4\dep4.proj");
+
+            projectRootElement.Save();
+            dep1.Save();
+            dep2.Save();
+            dep3.Save();
+            dep4.Save();
+
+            var expectedInputFiles = new[]
+            {
+                new PredictedItem(@"dep1\dep1.proj", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep1\dep1.targets", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.proj", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep2\dep2.targets", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep3\dep3.proj", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep3\dep3.targets", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep4\dep4.proj", nameof(ProjectFileAndImportsGraphPredictor)),
+                new PredictedItem(@"dep4\dep4.targets", nameof(ProjectFileAndImportsGraphPredictor)),
+            };
+
+            new ProjectFileAndImportsGraphPredictor()
+                .GetProjectPredictions(projectFile)
+                .AssertPredictions(
+                    _rootDir,
+                    expectedInputFiles,
+                    null,
+                    null,
+                    null);
+        }
+
+        private ProjectRootElement CreateDependencyProject(string projectName)
+        {
+            string projectDir = Path.Combine(_rootDir, projectName);
+            Directory.CreateDirectory(projectDir);
+
+            string projectFileName = projectName + ".proj";
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(projectDir, projectFileName));
+
+            string importFileName = projectName + ".targets";
+            ProjectRootElement importRootElement = ProjectRootElement.Create(Path.Combine(projectDir, importFileName));
+            importRootElement.Save();
+
+            projectRootElement.AddImport(importFileName);
+
+            // The caller may modify the returned project, so don't save it yet.
+            return projectRootElement;
+        }
+    }
+}

--- a/src/BuildPredictionTests/ProjectGraphPredictionExecutorTests.cs
+++ b/src/BuildPredictionTests/ProjectGraphPredictionExecutorTests.cs
@@ -1,0 +1,497 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Evaluation;
+    using Microsoft.Build.Execution;
+    using Microsoft.Build.Graph;
+    using Xunit;
+
+    public class ProjectGraphPredictionExecutorTests
+    {
+        private readonly string _rootDir;
+
+        public ProjectGraphPredictionExecutorTests()
+        {
+            // Isolate each test into its own folder
+            _rootDir = Path.Combine(Directory.GetCurrentDirectory(), nameof(ProjectGraphPredictionExecutorTests), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_rootDir);
+        }
+
+        [Fact]
+        public void EmptyPredictionsResultInEmptyAggregateResult()
+        {
+            var graphPredictors = new IProjectGraphPredictor[]
+            {
+                new MockGraphPredictor(null, null, null, null),
+                new MockGraphPredictor(null, null, null, null),
+            };
+
+            var predictors = new IProjectPredictor[]
+            {
+                new MockPredictor(null, null, null, null),
+                new MockPredictor(null, null, null, null),
+            };
+
+            var executor = new ProjectGraphPredictionExecutor(graphPredictors, predictors);
+
+            ProjectRootElement projectA = CreateProject("a");
+            ProjectRootElement projectB = CreateProject("b");
+            ProjectRootElement projectC = CreateProject("c");
+            ProjectRootElement projectD = CreateProject("d");
+
+            // A depends on B, D; B depends on C, D; C depends on D
+            projectA.AddItem("ProjectReference", @"..\b\b.proj");
+            projectA.AddItem("ProjectReference", @"..\d\d.proj");
+            projectB.AddItem("ProjectReference", @"..\c\c.proj");
+            projectB.AddItem("ProjectReference", @"..\d\d.proj");
+            projectC.AddItem("ProjectReference", @"..\d\d.proj");
+
+            projectA.Save();
+            projectB.Save();
+            projectC.Save();
+            projectD.Save();
+
+            var projectGraph = new ProjectGraph(projectA.FullPath, new ProjectCollection());
+            ProjectGraphPredictions graphPredictions = executor.PredictInputsAndOutputs(projectGraph);
+
+            AssertPredictionsMadeForEveryNode(projectGraph, graphPredictions);
+            foreach (ProjectPredictions projectPredictions in graphPredictions.PredictionsPerNode.Values)
+            {
+                projectPredictions.AssertNoPredictions();
+            }
+        }
+
+        [Fact]
+        public void DistinctInputsAndOutputsAreAggregated()
+        {
+            var graphPredictors = new IProjectGraphPredictor[]
+            {
+                new MockGraphPredictor(
+                    new[] { @"inputFile1" },
+                    new[] { @"inputDirectory1" },
+                    new[] { @"outputFile1" },
+                    new[] { @"outputDirectory1" }),
+                new MockGraphPredictor2(
+                    new[] { @"inputFile2" },
+                    new[] { @"inputDirectory2" },
+                    new[] { @"outputFile2" },
+                    new[] { @"outputDirectory2" }),
+            };
+
+            var predictors = new IProjectPredictor[]
+            {
+                new MockPredictor(
+                    new[] { @"inputFile3" },
+                    new[] { @"inputDirectory3" },
+                    new[] { @"outputFile3" },
+                    new[] { @"outputDirectory3" }),
+                new MockPredictor2(
+                    new[] { @"inputFile4" },
+                    new[] { @"inputDirectory4" },
+                    new[] { @"outputFile4" },
+                    new[] { @"outputDirectory4" }),
+            };
+
+            var executor = new ProjectGraphPredictionExecutor(graphPredictors, predictors);
+
+            ProjectRootElement projectA = CreateProject("a");
+            ProjectRootElement projectB = CreateProject("b");
+            ProjectRootElement projectC = CreateProject("c");
+            ProjectRootElement projectD = CreateProject("d");
+
+            // A depends on B, D; B depends on C, D; C depends on D
+            projectA.AddItem("ProjectReference", @"..\b\b.proj");
+            projectA.AddItem("ProjectReference", @"..\d\d.proj");
+            projectB.AddItem("ProjectReference", @"..\c\c.proj");
+            projectB.AddItem("ProjectReference", @"..\d\d.proj");
+            projectC.AddItem("ProjectReference", @"..\d\d.proj");
+
+            projectA.Save();
+            projectB.Save();
+            projectC.Save();
+            projectD.Save();
+
+            var projectGraph = new ProjectGraph(projectA.FullPath, new ProjectCollection());
+            ProjectGraphPredictions graphPredictions = executor.PredictInputsAndOutputs(projectGraph);
+
+            AssertPredictionsMadeForEveryNode(projectGraph, graphPredictions);
+
+            var expectedInputFiles = new[]
+            {
+                new PredictedItem(@"a\inputFile3", "MockPredictor"),
+                new PredictedItem(@"a\inputFile4", "MockPredictor2"),
+                new PredictedItem(@"b\inputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"b\inputFile2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\inputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputFile2", "MockGraphPredictor2"),
+            };
+            var expectedInputDirectories = new[]
+            {
+                new PredictedItem(@"a\inputDirectory3", "MockPredictor"),
+                new PredictedItem(@"a\inputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"b\inputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"b\inputDirectory2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\inputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputDirectory2", "MockGraphPredictor2"),
+            };
+            var expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"a\outputFile3", "MockPredictor"),
+                new PredictedItem(@"a\outputFile4", "MockPredictor2"),
+                new PredictedItem(@"b\outputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"b\outputFile2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\outputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputFile2", "MockGraphPredictor2"),
+            };
+            var expectedOutputDirectories = new[]
+            {
+                new PredictedItem(@"a\outputDirectory3", "MockPredictor"),
+                new PredictedItem(@"a\outputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"b\outputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"b\outputDirectory2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\outputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputDirectory2", "MockGraphPredictor2"),
+            };
+            GetPredictionsForProject(graphPredictions, "a").AssertPredictions(
+                _rootDir,
+                expectedInputFiles,
+                expectedInputDirectories,
+                expectedOutputFiles,
+                expectedOutputDirectories);
+
+            expectedInputFiles = new[]
+            {
+                new PredictedItem(@"b\inputFile3", "MockPredictor"),
+                new PredictedItem(@"b\inputFile4", "MockPredictor2"),
+                new PredictedItem(@"c\inputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"c\inputFile2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\inputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputFile2", "MockGraphPredictor2"),
+            };
+            expectedInputDirectories = new[]
+            {
+                new PredictedItem(@"b\inputDirectory3", "MockPredictor"),
+                new PredictedItem(@"b\inputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"c\inputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"c\inputDirectory2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\inputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputDirectory2", "MockGraphPredictor2"),
+            };
+            expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"b\outputFile3", "MockPredictor"),
+                new PredictedItem(@"b\outputFile4", "MockPredictor2"),
+                new PredictedItem(@"c\outputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"c\outputFile2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\outputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputFile2", "MockGraphPredictor2"),
+            };
+            expectedOutputDirectories = new[]
+            {
+                new PredictedItem(@"b\outputDirectory3", "MockPredictor"),
+                new PredictedItem(@"b\outputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"c\outputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"c\outputDirectory2", "MockGraphPredictor2"),
+                new PredictedItem(@"d\outputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputDirectory2", "MockGraphPredictor2"),
+            };
+            GetPredictionsForProject(graphPredictions, "b").AssertPredictions(
+                _rootDir,
+                expectedInputFiles,
+                expectedInputDirectories,
+                expectedOutputFiles,
+                expectedOutputDirectories);
+
+            expectedInputFiles = new[]
+            {
+                new PredictedItem(@"c\inputFile3", "MockPredictor"),
+                new PredictedItem(@"c\inputFile4", "MockPredictor2"),
+                new PredictedItem(@"d\inputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputFile2", "MockGraphPredictor2"),
+            };
+            expectedInputDirectories = new[]
+            {
+                new PredictedItem(@"c\inputDirectory3", "MockPredictor"),
+                new PredictedItem(@"c\inputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"d\inputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\inputDirectory2", "MockGraphPredictor2"),
+            };
+            expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"c\outputFile3", "MockPredictor"),
+                new PredictedItem(@"c\outputFile4", "MockPredictor2"),
+                new PredictedItem(@"d\outputFile1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputFile2", "MockGraphPredictor2"),
+            };
+            expectedOutputDirectories = new[]
+            {
+                new PredictedItem(@"c\outputDirectory3", "MockPredictor"),
+                new PredictedItem(@"c\outputDirectory4", "MockPredictor2"),
+                new PredictedItem(@"d\outputDirectory1", "MockGraphPredictor"),
+                new PredictedItem(@"d\outputDirectory2", "MockGraphPredictor2"),
+            };
+            GetPredictionsForProject(graphPredictions, "c").AssertPredictions(
+                _rootDir,
+                expectedInputFiles,
+                expectedInputDirectories,
+                expectedOutputFiles,
+                expectedOutputDirectories);
+
+            expectedInputFiles = new[]
+            {
+                new PredictedItem(@"d\inputFile3", "MockPredictor"),
+                new PredictedItem(@"d\inputFile4", "MockPredictor2"),
+            };
+            expectedInputDirectories = new[]
+            {
+                new PredictedItem(@"d\inputDirectory3", "MockPredictor"),
+                new PredictedItem(@"d\inputDirectory4", "MockPredictor2"),
+            };
+            expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"d\outputFile3", "MockPredictor"),
+                new PredictedItem(@"d\outputFile4", "MockPredictor2"),
+            };
+            expectedOutputDirectories = new[]
+            {
+                new PredictedItem(@"d\outputDirectory3", "MockPredictor"),
+                new PredictedItem(@"d\outputDirectory4", "MockPredictor2"),
+            };
+            GetPredictionsForProject(graphPredictions, "d").AssertPredictions(
+                _rootDir,
+                expectedInputFiles,
+                expectedInputDirectories,
+                expectedOutputFiles,
+                expectedOutputDirectories);
+        }
+
+        [Fact]
+        public void DuplicateInputsAndOutputsMergePredictedBys()
+        {
+            var graphPredictors = new IProjectGraphPredictor[]
+            {
+                new MockGraphPredictor(
+                    new[] { @"..\common\inputFile" },
+                    new[] { @"..\common\inputDirectory" },
+                    new[] { @"..\common\outputFile" },
+                    new[] { @"..\common\outputDirectory" }),
+                new MockGraphPredictor2(
+                    new[] { @"..\common\inputFile" },
+                    new[] { @"..\common\inputDirectory" },
+                    new[] { @"..\common\outputFile" },
+                    new[] { @"..\common\outputDirectory" }),
+            };
+
+            var predictors = new IProjectPredictor[]
+            {
+                new MockPredictor(
+                    new[] { @"..\common\inputFile" },
+                    new[] { @"..\common\inputDirectory" },
+                    new[] { @"..\common\outputFile" },
+                    new[] { @"..\common\outputDirectory" }),
+                new MockPredictor2(
+                    new[] { @"..\common\inputFile" },
+                    new[] { @"..\common\inputDirectory" },
+                    new[] { @"..\common\outputFile" },
+                    new[] { @"..\common\outputDirectory" }),
+            };
+
+            var executor = new ProjectGraphPredictionExecutor(graphPredictors, predictors);
+
+            ProjectRootElement projectA = CreateProject("a");
+            ProjectRootElement projectB = CreateProject("b");
+
+            // A depends on B
+            projectA.AddItem("ProjectReference", @"..\b\b.proj");
+
+            projectA.Save();
+            projectB.Save();
+
+            var projectGraph = new ProjectGraph(projectA.FullPath, new ProjectCollection());
+            ProjectGraphPredictions graphPredictions = executor.PredictInputsAndOutputs(projectGraph);
+
+            AssertPredictionsMadeForEveryNode(projectGraph, graphPredictions);
+
+            var expectedInputFiles = new[]
+            {
+                new PredictedItem(@"common\inputFile", "MockGraphPredictor", "MockGraphPredictor2", "MockPredictor", "MockPredictor2"),
+            };
+            var expectedInputDirectories = new[]
+            {
+                new PredictedItem(@"common\inputDirectory", "MockGraphPredictor", "MockGraphPredictor2", "MockPredictor", "MockPredictor2"),
+            };
+            var expectedOutputFiles = new[]
+            {
+                new PredictedItem(@"common\outputFile", "MockGraphPredictor", "MockGraphPredictor2", "MockPredictor", "MockPredictor2"),
+            };
+            var expectedOutputDirectories = new[]
+            {
+                new PredictedItem(@"common\outputDirectory", "MockGraphPredictor", "MockGraphPredictor2", "MockPredictor", "MockPredictor2"),
+            };
+
+            GetPredictionsForProject(graphPredictions, "a").AssertPredictions(
+                _rootDir,
+                expectedInputFiles,
+                expectedInputDirectories,
+                expectedOutputFiles,
+                expectedOutputDirectories);
+        }
+
+        private ProjectRootElement CreateProject(string projectName)
+        {
+            string projectPath = Path.Combine(_rootDir, projectName, projectName + ".proj");
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(projectPath);
+
+            // The caller may modify the returned project, so don't save it yet.
+            return projectRootElement;
+        }
+
+        private ProjectPredictions GetPredictionsForProject(ProjectGraphPredictions graphPredictions, string projectName)
+        {
+            string expectedFullPath = Path.Combine(_rootDir, projectName, projectName + ".proj");
+            foreach (KeyValuePair<ProjectGraphNode, ProjectPredictions> pair in graphPredictions.PredictionsPerNode)
+            {
+                if (pair.Key.ProjectInstance.FullPath.Equals(expectedFullPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    return pair.Value;
+                }
+            }
+
+            throw new InvalidOperationException($"Could not find predictions for project {projectName}");
+        }
+
+        private void AssertPredictionsMadeForEveryNode(ProjectGraph projectGraph, ProjectGraphPredictions graphPredictions)
+        {
+            Assert.Equal(projectGraph.ProjectNodes.Count, graphPredictions.PredictionsPerNode.Count);
+            foreach (ProjectGraphNode node in projectGraph.ProjectNodes)
+            {
+                graphPredictions.PredictionsPerNode.ContainsKey(node);
+            }
+        }
+
+        private class MockGraphPredictor : IProjectGraphPredictor
+        {
+            private readonly IEnumerable<string> _inputFiles;
+            private readonly IEnumerable<string> _inputDirectories;
+            private readonly IEnumerable<string> _outputFiles;
+            private readonly IEnumerable<string> _outputDirectories;
+
+            public MockGraphPredictor(
+                IEnumerable<string> inputFiles,
+                IEnumerable<string> inputDirectories,
+                IEnumerable<string> outputFiles,
+                IEnumerable<string> outputDirectories)
+            {
+                _inputFiles = inputFiles ?? Array.Empty<string>();
+                _inputDirectories = inputDirectories ?? Array.Empty<string>();
+                _outputFiles = outputFiles ?? Array.Empty<string>();
+                _outputDirectories = outputDirectories ?? Array.Empty<string>();
+            }
+
+            public void PredictInputsAndOutputs(ProjectGraphNode projectGraphNode, ProjectPredictionReporter predictionReporter)
+            {
+                foreach (ProjectGraphNode dependency in projectGraphNode.ProjectReferences)
+                {
+                    var dependencyDir = dependency.ProjectInstance.Directory;
+
+                    foreach (string item in _inputFiles)
+                    {
+                        predictionReporter.ReportInputFile(Path.GetFullPath(Path.Combine(dependencyDir, item)));
+                    }
+
+                    foreach (string item in _inputDirectories)
+                    {
+                        predictionReporter.ReportInputDirectory(Path.GetFullPath(Path.Combine(dependencyDir, item)));
+                    }
+
+                    foreach (string item in _outputFiles)
+                    {
+                        predictionReporter.ReportOutputFile(Path.GetFullPath(Path.Combine(dependencyDir, item)));
+                    }
+
+                    foreach (string item in _outputDirectories)
+                    {
+                        predictionReporter.ReportOutputDirectory(Path.GetFullPath(Path.Combine(dependencyDir, item)));
+                    }
+                }
+            }
+        }
+
+        private class MockPredictor : IProjectPredictor
+        {
+            private readonly IEnumerable<string> _inputFiles;
+            private readonly IEnumerable<string> _inputDirectories;
+            private readonly IEnumerable<string> _outputFiles;
+            private readonly IEnumerable<string> _outputDirectories;
+
+            public MockPredictor(
+                IEnumerable<string> inputFiles,
+                IEnumerable<string> inputDirectories,
+                IEnumerable<string> outputFiles,
+                IEnumerable<string> outputDirectories)
+            {
+                _inputFiles = inputFiles ?? Array.Empty<string>();
+                _inputDirectories = inputDirectories ?? Array.Empty<string>();
+                _outputFiles = outputFiles ?? Array.Empty<string>();
+                _outputDirectories = outputDirectories ?? Array.Empty<string>();
+            }
+
+            public void PredictInputsAndOutputs(
+                ProjectInstance projectInstance,
+                ProjectPredictionReporter predictionReporter)
+            {
+                foreach (var item in _inputFiles)
+                {
+                    predictionReporter.ReportInputFile(item);
+                }
+
+                foreach (var item in _inputDirectories)
+                {
+                    predictionReporter.ReportInputDirectory(item);
+                }
+
+                foreach (var item in _outputFiles)
+                {
+                    predictionReporter.ReportOutputFile(item);
+                }
+
+                foreach (var item in _outputDirectories)
+                {
+                    predictionReporter.ReportOutputDirectory(item);
+                }
+            }
+        }
+
+        // Second class name to get different results from PredictedBy values.
+        private class MockGraphPredictor2 : MockGraphPredictor
+        {
+            public MockGraphPredictor2(
+                IEnumerable<string> inputFiles,
+                IEnumerable<string> inputDirectories,
+                IEnumerable<string> outputFiles,
+                IEnumerable<string> outputDirectories)
+                : base(inputFiles, inputDirectories, outputFiles, outputDirectories)
+            {
+            }
+        }
+
+        // Second class name to get different results from PredictedBy values.
+        private class MockPredictor2 : MockPredictor
+        {
+            public MockPredictor2(
+                IEnumerable<string> inputFiles,
+                IEnumerable<string> inputDirectories,
+                IEnumerable<string> outputFiles,
+                IEnumerable<string> outputDirectories)
+                : base(inputFiles, inputDirectories, outputFiles, outputDirectories)
+            {
+            }
+        }
+    }
+}

--- a/src/BuildPredictionTests/ProjectPredictorsTests.cs
+++ b/src/BuildPredictionTests/ProjectPredictorsTests.cs
@@ -6,65 +6,23 @@ namespace Microsoft.Build.Prediction.Tests
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using Microsoft.Build.Prediction.Predictors;
     using Xunit;
 
     public class ProjectPredictorsTests
     {
         [Fact]
-        public void BasicPredictors()
-        {
-            var expectedPredictorTypes = new[]
-            {
-                typeof(AvailableItemNameItemsPredictor),
-                typeof(ContentItemsPredictor),
-                typeof(NoneItemsPredictor),
-                typeof(CompileItemsPredictor),
-                typeof(IntermediateOutputPathPredictor),
-                typeof(OutDirOrOutputPathPredictor),
-                typeof(ProjectFileAndImportsPredictor),
-                typeof(AzureCloudServicePredictor),
-                typeof(ServiceFabricServiceManifestPredictor),
-                typeof(AzureCloudServiceWorkerFilesPredictor),
-                typeof(CodeAnalysisRuleSetPredictor),
-                typeof(AssemblyOriginatorKeyFilePredictor),
-                typeof(EmbeddedResourceItemsPredictor),
-                typeof(ReferenceItemsPredictor),
-                typeof(StyleCopPredictor),
-                typeof(ManifestsPredictor),
-                typeof(VSCTCompileItemsPredictor),
-                typeof(EditorConfigFilesItemsPredictor),
-                typeof(ApplicationIconPredictor),
-                typeof(GeneratePackageOnBuildPredictor),
-                typeof(CompiledAssemblyPredictor),
-                typeof(DocumentationFilePredictor),
-                typeof(RefAssemblyPredictor),
-                typeof(SymbolsFilePredictor),
-                typeof(XamlAppDefPredictor),
-                typeof(TypeScriptCompileItemsPredictor),
-                typeof(ApplicationDefinitionItemsPredictor),
-                typeof(PageItemsPredictor),
-                typeof(ResourceItemsPredictor),
-                typeof(SplashScreenItemsPredictor),
-                typeof(TsConfigPredictor),
-            };
-
-            AssertPredictorsList(expectedPredictorTypes, ProjectPredictors.BasicPredictors);
-        }
+        public void AllProjectPredictors() => AssertAllPredictors(ProjectPredictors.AllProjectPredictors);
 
         [Fact]
-        public void AllPredictors()
+        public void AllProjectGraphPredictors() => AssertAllPredictors(ProjectPredictors.AllProjectGraphPredictors);
+
+        private static void AssertAllPredictors<T>(IReadOnlyCollection<T> actualPredictors)
         {
             // All predictors means all predictors. Use reflection to ensure we really did get all creatable IProjectPredictors.
-            Type[] expectedPredictorTypes = typeof(IProjectPredictor).Assembly.GetTypes()
-                .Where(type => !type.IsInterface && !type.IsAbstract && typeof(IProjectPredictor).IsAssignableFrom(type))
+            Type[] expectedPredictorTypes = typeof(T).Assembly.GetTypes()
+                .Where(type => !type.IsInterface && !type.IsAbstract && typeof(T).IsAssignableFrom(type))
                 .ToArray();
 
-            AssertPredictorsList(expectedPredictorTypes, ProjectPredictors.AllPredictors);
-        }
-
-        private static void AssertPredictorsList(Type[] expectedPredictorTypes, IReadOnlyCollection<IProjectPredictor> actualPredictors)
-        {
             Assert.Equal(expectedPredictorTypes.Length, actualPredictors.Count);
             foreach (Type predictorType in expectedPredictorTypes)
             {


### PR DESCRIPTION
This is a new feature which allows for "graph predictions" which are predictions which require multiple projects, for examples predictions of inputs/outputs based on dependencies (transitive copies, etc).