### PR TITLE
Use SHA2 signing cert

### DIFF
--- a/src/BuildPrediction/Microsoft.Build.Prediction.csproj
+++ b/src/BuildPrediction/Microsoft.Build.Prediction.csproj
@@ -15,10 +15,10 @@
 
   <ItemGroup>
     <FilesToSign Include="$(TargetPath)">
-      <Authenticode>Microsoft</Authenticode>
+      <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
     <FilesToSign Include="$(TargetRefPath)">
-      <Authenticode>Microsoft</Authenticode>
+      <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
     <SignNuGetPackFiles Include="$(PackageOutputPath)\$(AssemblyName).$(PackageVersion).snupkg" />
   </ItemGroup>


### PR DESCRIPTION
The Microsoft SHA1 cert is deprecated and new development
requires using a SHA2 cert; Microsoft400 is the equivalent.