### PR TITLE
Add MasmItemsPredictor

### DIFF
--- a/src/BuildPrediction/Predictors/MasmItemsPredictor.cs
+++ b/src/BuildPrediction/Predictors/MasmItemsPredictor.cs
@@ -1,0 +1,133 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Predictors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Linq;
+    using Microsoft.Build.Execution;
+
+    /// <summary>
+    /// Predicts inputs for Assembler files built as MASM items.
+    /// </summary>
+    /// <remarks>
+    /// MASM/ml64.exe, assembles and links one or more assembly-language source files.
+    ///
+    /// While not as widely used, the masm.props/masm.targets are distributed with Visual Studio C/C++ SDK:
+    /// - $(VCTargetsPath)\BuildCustomizations\masm.props
+    /// - $(VCTargetsPath)\BuildCustomizations\masm.targets
+    /// </remarks>
+    /// <seealso cref="Microsoft.Build.Prediction.IProjectPredictor" />
+    public class MasmItemsPredictor : IProjectPredictor
+    {
+        /// <summary>
+        /// Item name for a file to be assembled.
+        /// </summary>
+        internal const string MasmItemName = "MASM";
+
+        /// <summary>
+        /// Property name declared in masm.targets
+        /// </summary>
+        internal const string MasmBeforeTargetsPropertyName = "MASMBeforeTargets";
+
+        /// <summary>
+        /// Optional item meta data name that represents the paths for the assembler to generate an assembled code listing file.
+        /// </summary>
+        internal const string AssembledCodeListingFileMetadata = "AssembledCodeListingFile";
+
+        /// <summary>
+        /// Optional item meta data name that specifies whether to generate browse information file and its
+        /// optional name or location of the browse information file.
+        /// </summary>
+        internal const string BrowseFileMetadata = "BrowseFile";
+
+        /// <summary>
+        /// Item meta data name that determines if the item group should skipped, and not assembled.
+        /// </summary>
+        internal const string ExcludedFromBuildMetadata = "ExcludedFromBuild";
+
+        /// <summary>
+        /// Item meta data name that represents the fully qualified path to the assembler output.
+        /// </summary>
+        internal const string ObjectFileNameMetadata = "ObjectFileName";
+
+        /// <summary>
+        /// Item meta data name that represents the paths for the assembler to search for include file(s).
+        /// </summary>
+        internal const string IncludePathsMetadata = "IncludePaths";
+
+        /// <summary>
+        /// Character separator for values specified in %(MASM.IncludePaths).
+        /// </summary>
+        private static readonly char[] IncludePathsSeparator = { ';' };
+
+        /// <inheritdoc />
+        public void PredictInputsAndOutputs(ProjectInstance project, ProjectPredictionReporter reporter)
+        {
+            // This is based on $(VCTargetsPath)\BuildCustomizations\masm.targets, if the before targets
+            // property isn't set then the masm.targets haven't been imported, and no @(MASM) items will
+            // be processed by the MASM targets.
+            if (string.IsNullOrWhiteSpace(project.GetPropertyValue(MasmBeforeTargetsPropertyName)))
+            {
+                return;
+            }
+
+            ICollection<ProjectItemInstance> masmItems = project.GetItems(MasmItemName);
+            if (masmItems.Count == 0)
+            {
+                return;
+            }
+
+            var reportedIncludes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (ProjectItemInstance masmItem in masmItems)
+            {
+                if (IsExcludedFromBuild(masmItem))
+                {
+                    continue;
+                }
+
+                ReportInputs(reporter, masmItem, reportedIncludes);
+                ReportOutputs(reporter, masmItem);
+            }
+        }
+
+        private bool IsExcludedFromBuild(ProjectItemInstance masmItem) =>
+            masmItem.GetMetadataValue(ExcludedFromBuildMetadata).Equals(bool.TrueString, StringComparison.OrdinalIgnoreCase);
+
+        private void ReportInputs(ProjectPredictionReporter reporter, ProjectItemInstance masmItem, HashSet<string> reportedIncludes)
+        {
+            reporter.ReportInputFile(masmItem.EvaluatedInclude);
+
+            string[] includePaths = masmItem.GetMetadataValue(IncludePathsMetadata)
+                .Split(IncludePathsSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            // Avoid reporting paths that we've already reported for this project.
+            foreach (string includePath in includePaths)
+            {
+                if (reportedIncludes.Add(includePath))
+                {
+                    reporter.ReportInputDirectory(includePath);
+                }
+            }
+        }
+
+        private void ReportOutputs(ProjectPredictionReporter reporter, ProjectItemInstance masmItem)
+        {
+            reporter.ReportOutputFile(masmItem.GetMetadataValue(ObjectFileNameMetadata));
+
+            string assembledCodeListingFile = masmItem.GetMetadataValue(AssembledCodeListingFileMetadata);
+            if (!string.IsNullOrWhiteSpace(assembledCodeListingFile))
+            {
+                reporter.ReportOutputFile(assembledCodeListingFile);
+            }
+
+            string browseFile = masmItem.GetMetadataValue(BrowseFileMetadata);
+            if (!string.IsNullOrWhiteSpace(browseFile))
+            {
+                reporter.ReportOutputFile(browseFile);
+            }
+        }
+    }
+}

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Build.Prediction
     public static class ProjectPredictors
     {
         /// <summary>
-        /// Gets a collection of all <see cref="IProjectPredictor"/>s. This is for convencience to avoid needing to specify all predictors explicitly.
+        /// Gets a collection of all <see cref="IProjectPredictor"/>s. This is for convenience to avoid needing to specify all predictors explicitly.
         /// </summary>
         /// <remarks>
         /// This includes the following predictors:
@@ -52,6 +52,7 @@ namespace Microsoft.Build.Prediction
         /// <item><see cref="ResourceItemsPredictor"/></item>
         /// <item><see cref="SplashScreenItemsPredictor"/></item>
         /// <item><see cref="TsConfigPredictor"/></item>
+        /// <item><see cref="MasmItemsPredictor"/></item>
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
@@ -90,11 +91,12 @@ namespace Microsoft.Build.Prediction
             new ResourceItemsPredictor(),
             new SplashScreenItemsPredictor(),
             new TsConfigPredictor(),
+            new MasmItemsPredictor(),
             //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
         };
 
         /// <summary>
-        /// Gets a collection of all <see cref="IProjectGraphPredictor"/>s. This is for convencience to avoid needing to specify all graph predictors explicitly.
+        /// Gets a collection of all <see cref="IProjectGraphPredictor"/>s. This is for convenience to avoid needing to specify all graph predictors explicitly.
         /// </summary>
         /// <remarks>
         /// This includes the following graph predictors:

--- a/src/BuildPredictionTests/Predictors/MasmItemsPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/MasmItemsPredictorTests.cs
@@ -1,0 +1,137 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Build.Prediction.Tests.Predictors
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Build.Construction;
+    using Microsoft.Build.Prediction.Predictors;
+    using Xunit;
+
+    public class MasmItemsPredictorTests
+    {
+        private const string AsmFile = "Foo.asm";
+
+        private const string ObjFile = "Foo.obj";
+
+        private const string ListingFile = "listing.txt";
+
+        private const string BrowseFile = "browse.txt";
+
+        private static readonly KeyValuePair<string, string> MasmItemMetadata =
+            CreateMetaData(MasmItemsPredictor.IncludePathsMetadata, "asm-include;asm-include2");
+
+        private static readonly PredictedItem[] ExpectedInputFiles = new[]
+        {
+            new PredictedItem(AsmFile, nameof(MasmItemsPredictor)),
+        };
+
+        private static readonly PredictedItem[] ExpectedOutputFiles = new[]
+        {
+            new PredictedItem(ObjFile, nameof(MasmItemsPredictor)),
+        };
+
+        private static readonly PredictedItem[] ExpectedInputDirectories = new[]
+        {
+            new PredictedItem("asm-include", nameof(MasmItemsPredictor)),
+            new PredictedItem("asm-include2", nameof(MasmItemsPredictor)),
+        };
+
+        [Fact]
+        public void MasmItemsWithMetadataInline()
+        {
+            ProjectRootElement project = CreateMasmTestProject();
+            project.AddItem(MasmItemsPredictor.MasmItemName, AsmFile, new[] { MasmItemMetadata });
+
+            project.AssertPredictions<MasmItemsPredictor>(
+                ExpectedInputFiles,
+                ExpectedInputDirectories,
+                ExpectedOutputFiles,
+                null);
+        }
+
+        [Fact]
+        public void MasmItemsWithItemGroupDefinitionMetadata()
+        {
+            ProjectRootElement project = CreateMasmTestProject();
+
+            project.AddItemDefinition(MasmItemsPredictor.MasmItemName)
+                .AddMetadata(MasmItemMetadata.Key, MasmItemMetadata.Value);
+
+            project.AddItem(MasmItemsPredictor.MasmItemName, AsmFile);
+
+            project.AssertPredictions<MasmItemsPredictor>(
+                ExpectedInputFiles,
+                ExpectedInputDirectories,
+                ExpectedOutputFiles,
+                null);
+        }
+
+        [Fact]
+        public void MasmItemsWithBrowseFile()
+        {
+            ProjectRootElement project = CreateMasmTestProject();
+
+            var browseFileMetadata = CreateMetaData(MasmItemsPredictor.BrowseFileMetadata, BrowseFile);
+            project.AddItem(MasmItemsPredictor.MasmItemName, AsmFile, new[] { browseFileMetadata, MasmItemMetadata });
+
+            project.AssertPredictions<MasmItemsPredictor>(
+                ExpectedInputFiles,
+                ExpectedInputDirectories,
+                ExpectedOutputFiles.Union(PredictItems(BrowseFile)).ToArray(),
+                null);
+        }
+
+        [Fact]
+        public void MasmItemsWithAssembledCodeListingFile()
+        {
+            ProjectRootElement project = CreateMasmTestProject();
+
+            var listingFileMetadata = CreateMetaData(MasmItemsPredictor.AssembledCodeListingFileMetadata, ListingFile);
+            project.AddItem(MasmItemsPredictor.MasmItemName, AsmFile, new[] { listingFileMetadata, MasmItemMetadata });
+
+            project.AssertPredictions<MasmItemsPredictor>(
+                ExpectedInputFiles,
+                ExpectedInputDirectories,
+                ExpectedOutputFiles.Union(PredictItems(ListingFile)).ToArray(),
+                null);
+        }
+
+        [Fact]
+        public void MasmItemsExcludedFromBuild()
+        {
+            ProjectRootElement project = CreateMasmTestProject();
+
+            var excludeMetadata = CreateMetaData(MasmItemsPredictor.ExcludedFromBuildMetadata, bool.TrueString);
+            project.AddItem(MasmItemsPredictor.MasmItemName, AsmFile, new[] { excludeMetadata });
+
+            // Validate that if the MASM item is defined, but marked ExcludedFromBuild that we don't emit it.
+            project.AssertNoPredictions<MasmItemsPredictor>();
+        }
+
+        private static KeyValuePair<string, string> CreateMetaData(string name, string value) =>
+            new KeyValuePair<string, string>(name, value);
+
+        private ProjectRootElement CreateMasmTestProject()
+        {
+            ProjectRootElement projectRootElement = ProjectRootElement.Create();
+            projectRootElement.AddImport(@"$(VCTargetsPath)\BuildCustomizations\masm.props");
+            projectRootElement.AddImport(@"$(VCTargetsPath)\BuildCustomizations\masm.targets");
+
+            return projectRootElement;
+        }
+
+        private PredictedItem[] PredictItems(params string[] predictions)
+        {
+            PredictedItem[] items = new PredictedItem[predictions.Length];
+
+            for (int i = 0; i < predictions.Length; i++)
+            {
+                items[i] = new PredictedItem(predictions[i], nameof(MasmItemsPredictor));
+            }
+
+            return items;
+        }
+    }
+}

--- a/src/BuildPredictionTests/TestHelpers.cs
+++ b/src/BuildPredictionTests/TestHelpers.cs
@@ -26,6 +26,16 @@ namespace Microsoft.Build.Prediction.Tests
 
         public static void AssertNoPredictions(this ProjectPredictions predictions) => predictions.AssertPredictions(null, null, null, null);
 
+        public static void AssertNoPredictions<TPredictor>(
+            this ProjectRootElement rootElement)
+            where TPredictor : IProjectPredictor, new()
+        {
+            ProjectInstance instance = CreateProjectInstanceFromRootElement(rootElement);
+
+            new TPredictor().GetProjectPredictions(instance)
+                .AssertNoPredictions();
+        }
+
         public static void AssertPredictions(
             this ProjectPredictions predictions,
             ProjectInstance projectInstance,
@@ -54,6 +64,25 @@ namespace Microsoft.Build.Prediction.Tests
                 expectedInputDirectories.MakeAbsolute(rootDir),
                 expectedOutputFiles.MakeAbsolute(rootDir),
                 expectedOutputDirectories.MakeAbsolute(rootDir));
+
+        public static void AssertPredictions<TPredictor>(
+            this ProjectRootElement rootElement,
+            IReadOnlyCollection<PredictedItem> expectedInputFiles,
+            IReadOnlyCollection<PredictedItem> expectedInputDirectories,
+            IReadOnlyCollection<PredictedItem> expectedOutputFiles,
+            IReadOnlyCollection<PredictedItem> expectedOutputDirectories)
+             where TPredictor : IProjectPredictor, new()
+         {
+            ProjectInstance instance = CreateProjectInstanceFromRootElement(rootElement);
+
+            new TPredictor().GetProjectPredictions(instance)
+                .AssertPredictions(
+                    instance,
+                    expectedInputFiles,
+                    expectedInputDirectories,
+                    expectedOutputFiles,
+                    expectedOutputDirectories);
+        }
 
         public static ProjectInstance ProjectInstanceFromXml(string xml)
         {


### PR DESCRIPTION
VS ships with masm.props / masm.targets:
- $(VCTargetsPath)\BuildCustomizations\masm.props
- $(VCTargetsPath)\BuildCustomizations\masm.targets

They are used to compile .asm files via the ml64.exe assembler.

The targets the input .asm files @(MASM), as well as a set of include
directories that the assembler pre-processor will use to search
for files included in the .asm file %(MASM.IncludePaths).

The targets will write the output object file to %(MASM.ObjectFileName).
It also supports a few other options which will emit files, which the
predictor also supports (AssembledCodeListingFile, BrowseFile).