### PR TITLE
MasmItemsPredictor: Trim leading/trailing whitespace from IncludePaths.

### DIFF
--- a/src/BuildPrediction/Predictors/MasmItemsPredictor.cs
+++ b/src/BuildPrediction/Predictors/MasmItemsPredictor.cs
@@ -106,9 +106,10 @@ namespace Microsoft.Build.Prediction.Predictors
             // Avoid reporting paths that we've already reported for this project.
             foreach (string includePath in includePaths)
             {
-                if (reportedIncludes.Add(includePath))
+                string trimmedPath = includePath.Trim();
+                if (!string.IsNullOrEmpty(trimmedPath) && reportedIncludes.Add(trimmedPath))
                 {
-                    reporter.ReportInputDirectory(includePath);
+                    reporter.ReportInputDirectory(trimmedPath);
                 }
             }
         }


### PR DESCRIPTION
When stepping through the code in the debugger on a real world usage
I realized that we weren't trimming white space properly.