### PR TITLE
ServiceFabricPackageRootFilesGraphPredictor: Fix for linked package files

### DIFF
--- a/src/BuildPrediction/Predictors/ServiceFabricPackageRootFilesGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/ServiceFabricPackageRootFilesGraphPredictor.cs
@@ -90,8 +90,8 @@ namespace Microsoft.Build.Prediction.Predictors
                 string linkMetadata = item.GetMetadataValue("Link");
                 if (!string.IsNullOrEmpty(linkMetadata))
                 {
-                    packageFileFullPath = Path.GetFullPath(Path.Combine(projectFolder, linkMetadata));
-                    if (packageFileFullPath.StartsWith(packageRootPath, StringComparison.OrdinalIgnoreCase))
+                    string linkFullPath = Path.GetFullPath(Path.Combine(projectFolder, linkMetadata));
+                    if (linkFullPath.StartsWith(packageRootPath, StringComparison.OrdinalIgnoreCase))
                     {
                         predictionReporter.ReportInputFile(packageFileFullPath);
                         continue;

--- a/src/BuildPredictionTests/Predictors/ServiceFabricPackageRootFilesGraphPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/ServiceFabricPackageRootFilesGraphPredictorTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
             // Linked package file
             string dependency3File = Path.Combine(_rootDir, @"dep3\dep3.csproj");
             ProjectRootElement dependency3RootElement = ProjectRootElement.Create(dependency3File);
-            dependency3RootElement.AddItem(ContentItemsPredictor.ContentItemName, @"..\some\crazy\path.xml")
+            dependency3RootElement.AddItem(ContentItemsPredictor.ContentItemName, @"..\dep3_linked\PackageRoot\Config\Settings.xml")
                 .AddMetadata("Link", @"PackageRoot\Config\Settings.xml");
             Directory.CreateDirectory(Path.Combine(_rootDir, @"dep3\PackageRoot"));
 
@@ -66,7 +66,7 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
             {
                 new PredictedItem(@"dep1\PackageRoot\Config\Settings.xml", nameof(ServiceFabricPackageRootFilesGraphPredictor)),
                 new PredictedItem(@"dep2\PackageRoot\Config\Settings.xml", nameof(ServiceFabricPackageRootFilesGraphPredictor)),
-                new PredictedItem(@"dep3\PackageRoot\Config\Settings.xml", nameof(ServiceFabricPackageRootFilesGraphPredictor)),
+                new PredictedItem(@"dep3_linked\PackageRoot\Config\Settings.xml", nameof(ServiceFabricPackageRootFilesGraphPredictor)),
                 new PredictedItem(@"dep4\PackageRoot\Config\Settings.xml", nameof(ServiceFabricPackageRootFilesGraphPredictor)),
             };
             new ServiceFabricPackageRootFilesGraphPredictor()
@@ -105,7 +105,7 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
             // Linked package file
             string dependency3File = Path.Combine(_rootDir, @"dep3\dep3.csproj");
             ProjectRootElement dependency3RootElement = ProjectRootElement.Create(dependency3File);
-            dependency3RootElement.AddItem(ContentItemsPredictor.ContentItemName, @"..\some\crazy\path.xml")
+            dependency3RootElement.AddItem(ContentItemsPredictor.ContentItemName, @"..\dep3_linked\PackageRoot\Config\Settings.xml")
                 .AddMetadata("Link", @"PackageRoot\Config\Settings.xml");
             Directory.CreateDirectory(Path.Combine(_rootDir, @"dep3\PackageRoot"));
 


### PR DESCRIPTION
ServiceFabricPackageRootFilesGraphPredictor: Fix for linked package files

This was predicting the destination of the link, which isn't a real file. Instead it should predict the source file of the link.