### PR TITLE
Fix publishing to NuGet.org

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -62,6 +62,12 @@ extends:
             condition: always()
             targetPath: $(LogDirectory)
             artifactName: 'logs'
+          - output: nuget
+            displayName: 'Push NuGet Packages to nuget.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/v'))
+            packagesToPush: '$(Pipeline.Workspace)/artifacts/**/Microsoft.Build.Prediction*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'NuGet-1ES-Full'
         steps:
         - script: 'echo ##vso[task.setvariable variable=SignType;]Real'
           displayName: 'Set SignType to Real for tagged commits'


### PR DESCRIPTION
In the migration to 1ES PT (#103) this step was lost.