### PR TITLE
ArtifactsSdkPredictor: Fix Artifact item name

### DIFF
--- a/src/BuildPrediction/Predictors/ArtifactsSdkPredictor.cs
+++ b/src/BuildPrediction/Predictors/ArtifactsSdkPredictor.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Build.Prediction.Predictors
     {
         internal const string UsingMicrosoftArtifactsSdkPropertyName = "UsingMicrosoftArtifactsSdk";
 
+        internal const string EnableArtifactsPropertyName = "EnableArtifacts";
+
         internal const string ArtifactsItemName = "Artifact";
 
         internal const string RobocopyItemName = "Robocopy";
@@ -46,6 +48,13 @@ namespace Microsoft.Build.Prediction.Predictors
             // This predictor only applies to projects using the Microsoft.Build.Artifacts Sdk.
             var usingMicrosoftArtifactsSdk = projectInstance.GetPropertyValue(UsingMicrosoftArtifactsSdkPropertyName);
             if (!usingMicrosoftArtifactsSdk.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+
+            // Check property which disables the functionality.
+            var enableArtifacts = projectInstance.GetPropertyValue(EnableArtifactsPropertyName);
+            if (enableArtifacts.Equals("false", StringComparison.OrdinalIgnoreCase))
             {
                 return;
             }

--- a/src/BuildPrediction/Predictors/ArtifactsSdkPredictor.cs
+++ b/src/BuildPrediction/Predictors/ArtifactsSdkPredictor.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Build.Prediction.Predictors
     {
         internal const string UsingMicrosoftArtifactsSdkPropertyName = "UsingMicrosoftArtifactsSdk";
 
-        internal const string ArtifactsItemName = "Artifacts";
+        internal const string ArtifactsItemName = "Artifact";
 
         internal const string RobocopyItemName = "Robocopy";
 

--- a/src/BuildPredictionTests/Predictors/ArtifactsSdkPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/ArtifactsSdkPredictorTests.cs
@@ -41,6 +41,26 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
         }
 
         [Fact]
+        public void SkipWhenDisabled()
+        {
+            ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(_rootDir, @"src\project.csproj"));
+            projectRootElement.AddProperty(ArtifactsSdkPredictor.UsingMicrosoftArtifactsSdkPropertyName, "true");
+            projectRootElement.AddProperty(ArtifactsSdkPredictor.EnableArtifactsPropertyName, "false");
+            projectRootElement.AddProperty("ArtifactsPath", Path.Combine(_rootDir, "out"));
+
+            var artifactItem = projectRootElement.AddItem(ArtifactsSdkPredictor.ArtifactsItemName, "Artifact.txt");
+            artifactItem.AddMetadata(ArtifactsSdkPredictor.DestinationFolderMetadata, @"$(ArtifactsPath)\Project");
+
+            Directory.CreateDirectory(Path.Combine(_rootDir, "src"));
+            File.WriteAllText(Path.Combine(_rootDir, @"src\Artifact.txt"), "SomeContent");
+
+            ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+            new ArtifactsSdkPredictor()
+                .GetProjectPredictions(projectInstance)
+                .AssertNoPredictions();
+        }
+
+        [Fact]
         public void FindArtifactsForExistingFile()
         {
             ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(_rootDir, @"src\project.csproj"));


### PR DESCRIPTION
The item name is `Artifact`, not `Artifacts`.

https://github.com/microsoft/MSBuildSdks/blob/main/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets#L36

Also consider the `$(EnableArtifacts)` property.