### PR TITLE
Add predictions for deps.json and runtimeconfig.json files

### DIFF
--- a/src/BuildPrediction/Predictors/GenerateBuildDependencyFilePredictor.cs
+++ b/src/BuildPrediction/Predictors/GenerateBuildDependencyFilePredictor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Prediction.Predictors;
+
+/// <summary>
+/// Makes predictions based on the GenerateBuildDependencyFile target.
+/// </summary>
+public sealed class GenerateBuildDependencyFilePredictor : IProjectPredictor
+{
+    internal const string GenerateDependencyFilePropertyName = "GenerateDependencyFile";
+    internal const string ProjectAssetsFilePropertyName = "ProjectAssetsFile";
+    internal const string ProjectDepsFilePathPropertyName = "ProjectDepsFilePath";
+
+    /// <inheritdoc/>
+    public void PredictInputsAndOutputs(
+        ProjectInstance projectInstance,
+        ProjectPredictionReporter predictionReporter)
+    {
+        if (!projectInstance.GetPropertyValue(GenerateDependencyFilePropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        predictionReporter.ReportInputFile(projectInstance.GetPropertyValue(ProjectAssetsFilePropertyName));
+        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectDepsFilePathPropertyName));
+    }
+}

--- a/src/BuildPrediction/Predictors/GeneratePublishDependencyFilePredictor.cs
+++ b/src/BuildPrediction/Predictors/GeneratePublishDependencyFilePredictor.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Prediction.Predictors;
+
+/// <summary>
+/// Makes predictions based on the GeneratePublishDependencyFile target.
+/// </summary>
+public sealed class GeneratePublishDependencyFilePredictor : IProjectPredictor
+{
+    internal const string PublishAotPropertyName = "PublishAot";
+    internal const string PublishDirPropertyName = "PublishDir";
+    internal const string PublishSingleFilePropertyName = "PublishSingleFile";
+    internal const string SelfContainedPropertyName = "SelfContained";
+    internal const string PreserveStoreLayoutPropertyName = "PreserveStoreLayout";
+    internal const string PublishTrimmedPropertyName = "PublishTrimmed";
+    internal const string RuntimeStorePackagesItemName = "RuntimeStorePackages";
+    internal const string PackageReferenceItemName = "PackageReference";
+    internal const string PrivateAssetsMetadataName = "PrivateAssets";
+    internal const string PublishMetadataName = "Publish";
+    internal const string PublishDepsFilePathPropertyName = "PublishDepsFilePath";
+    internal const string ProjectDepsFileNamePropertyName = "ProjectDepsFileName";
+    internal const string IntermediateOutputPathPropertyName = "IntermediateOutputPath";
+
+    /// <inheritdoc/>
+    public void PredictInputsAndOutputs(
+        ProjectInstance projectInstance,
+        ProjectPredictionReporter predictionReporter)
+    {
+        if (!projectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName).Equals("true", StringComparison.OrdinalIgnoreCase)
+            || ShouldUseBuildDependencyFile(projectInstance)
+            || projectInstance.GetPropertyValue(PublishAotPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        predictionReporter.ReportInputFile(projectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName));
+
+        string publishDepsFilePath = GetEffectivePublishDepsFilePath(projectInstance);
+        string intermediateDepsFilePath = publishDepsFilePath is not null
+            ? publishDepsFilePath
+            : projectInstance.GetPropertyValue(IntermediateOutputPathPropertyName) + projectInstance.GetPropertyValue(ProjectDepsFileNamePropertyName);
+        predictionReporter.ReportOutputFile(intermediateDepsFilePath);
+
+        // Note: GetCopyToPublishDirectoryItemsGraphPredictor will predict the final (published) location for the publish deps file since that's the target which does that copy.
+    }
+
+    /// <summary>
+    /// Determines the value of _UseBuildDependencyFile by emulating the behavior from the _ComputeUseBuildDependencyFile target (and the _ComputePackageReferencePublish target).
+    /// </remarks>
+    internal static bool ShouldUseBuildDependencyFile(ProjectInstance projectInstance)
+    {
+        bool hasExcludeFromPublishPackageReference = false;
+        foreach (ProjectItemInstance packageReference in projectInstance.GetItems(PackageReferenceItemName))
+        {
+            string packageReferencePublishMetadata = packageReference.GetMetadataValue(PublishMetadataName);
+            if (packageReferencePublishMetadata.Equals("false", StringComparison.OrdinalIgnoreCase))
+            {
+                hasExcludeFromPublishPackageReference = true;
+                break;
+            }
+
+            if (string.IsNullOrEmpty(packageReferencePublishMetadata)
+                && packageReference.GetMetadataValue(PrivateAssetsMetadataName).Equals("All", StringComparison.OrdinalIgnoreCase))
+            {
+                hasExcludeFromPublishPackageReference = true;
+                break;
+            }
+        }
+
+        bool trimRuntimeAssets = projectInstance.GetPropertyValue(PublishSingleFilePropertyName).Equals("true", StringComparison.OrdinalIgnoreCase)
+            && projectInstance.GetPropertyValue(SelfContainedPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase);
+        return !hasExcludeFromPublishPackageReference
+            && projectInstance.GetItems(RuntimeStorePackagesItemName).Count == 0
+            && !projectInstance.GetPropertyValue(PreserveStoreLayoutPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase)
+            && !projectInstance.GetPropertyValue(PublishTrimmedPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase)
+            && !trimRuntimeAssets;
+    }
+
+    /// <summary>
+    /// Calculates the effective value of $(PublishDepsFilePath). In unspecified, the default value is calculated inside the GeneratePublishDependencyFile target.
+    /// </summary>
+    /// <remarks>
+    /// This can return null in the case of PublishSingleFile since the deps.json file is embedded within the single-file bundle.
+    /// </remarks>
+    internal static string GetEffectivePublishDepsFilePath(ProjectInstance projectInstance)
+    {
+        string publishDepsFilePath = projectInstance.GetPropertyValue(PublishDepsFilePathPropertyName);
+        if (!string.IsNullOrEmpty(publishDepsFilePath))
+        {
+            return publishDepsFilePath;
+        }
+
+        if (!projectInstance.GetPropertyValue(PublishSingleFilePropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            return projectInstance.GetPropertyValue(PublishDirPropertyName) + projectInstance.GetPropertyValue(ProjectDepsFileNamePropertyName);
+        }
+
+        return null;
+    }
+}

--- a/src/BuildPrediction/Predictors/GenerateRuntimeConfigurationFilesPredictor.cs
+++ b/src/BuildPrediction/Predictors/GenerateRuntimeConfigurationFilesPredictor.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Execution;
+
+namespace Microsoft.Build.Prediction.Predictors;
+
+/// <summary>
+/// Makes predictions based on the GenerateRuntimeConfigurationFiles target.
+/// </summary>
+public sealed class GenerateRuntimeConfigurationFilesPredictor : IProjectPredictor
+{
+    internal const string GenerateRuntimeConfigurationFilesPropertyName = "GenerateRuntimeConfigurationFiles";
+    internal const string UserRuntimeConfigPropertyName = "UserRuntimeConfig";
+    internal const string ProjectRuntimeConfigFilePathPropertyName = "ProjectRuntimeConfigFilePath";
+    internal const string ProjectRuntimeConfigDevFilePathPropertyName = "ProjectRuntimeConfigDevFilePath";
+
+    /// <inheritdoc/>
+    public void PredictInputsAndOutputs(
+        ProjectInstance projectInstance,
+        ProjectPredictionReporter predictionReporter)
+    {
+        if (!projectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        string userRuntimeConfig = projectInstance.GetPropertyValue(UserRuntimeConfigPropertyName);
+        string userRuntimeConfigFullPath = Path.Combine(projectInstance.Directory, userRuntimeConfig);
+        if (File.Exists(userRuntimeConfigFullPath))
+        {
+            predictionReporter.ReportInputFile(userRuntimeConfigFullPath);
+        }
+
+        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectRuntimeConfigFilePathPropertyName));
+        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectRuntimeConfigDevFilePathPropertyName));
+    }
+}

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -61,6 +61,9 @@ namespace Microsoft.Build.Prediction
         /// <item><see cref="CppContentFilesProjectOutputGroupPredictor"/></item>
         /// <item><see cref="LinkItemsPredictor"/></item>
         /// <item><see cref="DotnetSdkPredictor"/></item>
+        /// <item><see cref="GenerateBuildDependencyFilePredictor"/></item>
+        /// <item><see cref="GeneratePublishDependencyFilePredictor"/></item>
+        /// <item><see cref="GenerateRuntimeConfigurationFilesPredictor"/></item>
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
@@ -108,6 +111,9 @@ namespace Microsoft.Build.Prediction
             new CppContentFilesProjectOutputGroupPredictor(),
             new LinkItemsPredictor(),
             new DotnetSdkPredictor(),
+            new GenerateBuildDependencyFilePredictor(),
+            new GeneratePublishDependencyFilePredictor(),
+            new GenerateRuntimeConfigurationFilesPredictor(),
             //// NOTE! When adding a new predictor here, be sure to update the doc comment above.
         };
 

--- a/src/BuildPredictionTests/Predictors/GenerateBuildDependencyFilePredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/GenerateBuildDependencyFilePredictorTests.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Prediction.Predictors;
+using Xunit;
+
+namespace Microsoft.Build.Prediction.Tests.Predictors;
+
+public class GenerateBuildDependencyFilePredictorTests
+{
+    [Fact]
+    public void DoesNotGenerateDependencyFile()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        new GenerateBuildDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    [Fact]
+    public void GeneratesDependencyFile()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName, "true");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        var expectedInputFiles = new[]
+        {
+            new PredictedItem(projectAssetsFile, nameof(GenerateBuildDependencyFilePredictor)),
+        };
+        var expectedOutputFiles = new[]
+        {
+            new PredictedItem(projectDepsFilePath, nameof(GenerateBuildDependencyFilePredictor)),
+        };
+
+        new GenerateBuildDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                expectedInputFiles,
+                null,
+                expectedOutputFiles,
+                null);
+    }
+}

--- a/src/BuildPredictionTests/Predictors/GeneratePublishDependencyFilePredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/GeneratePublishDependencyFilePredictorTests.cs
@@ -1,0 +1,146 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Prediction.Predictors;
+using Xunit;
+
+namespace Microsoft.Build.Prediction.Tests.Predictors;
+
+public class GeneratePublishDependencyFilePredictorTests
+{
+    [Fact]
+    public void DoesNotGenerateDependencyFile()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.IntermediateOutputPathPropertyName, @"obj\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishDirPropertyName, @"bin\x64\Debug\net8.0\publish\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.ProjectDepsFileNamePropertyName, "project.deps.json");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        new GeneratePublishDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    [Fact]
+    public void UseBuildDependencyFile()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName, "true");
+
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.IntermediateOutputPathPropertyName, @"obj\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishDirPropertyName, @"bin\x64\Debug\net8.0\publish\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.ProjectDepsFileNamePropertyName, "project.deps.json");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        new GeneratePublishDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    [Fact]
+    public void PublishTrimmed()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName, "true");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.SelfContainedPropertyName, "true");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishTrimmedPropertyName, "true");
+
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.IntermediateOutputPathPropertyName, @"obj\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishDirPropertyName, @"bin\x64\Debug\net8.0\publish\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.ProjectDepsFileNamePropertyName, "project.deps.json");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        var expectedInputFiles = new[]
+        {
+            new PredictedItem(projectAssetsFile, nameof(GeneratePublishDependencyFilePredictor)),
+        };
+        var expectedOutputFiles = new[]
+        {
+            new PredictedItem(@"bin\x64\Debug\net8.0\publish\project.deps.json", nameof(GeneratePublishDependencyFilePredictor)),
+        };
+
+        new GeneratePublishDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                expectedInputFiles,
+                null,
+                expectedOutputFiles.MakeAbsolute(projectRootElement.DirectoryPath),
+                null);
+    }
+
+    [Fact]
+    public void PublishSingleFile()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create("project.csproj");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName, "true");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.SelfContainedPropertyName, "true");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishSingleFilePropertyName, "true");
+
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.IntermediateOutputPathPropertyName, @"obj\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.PublishDirPropertyName, @"bin\x64\Debug\net8.0\publish\");
+        projectRootElement.AddProperty(GeneratePublishDependencyFilePredictor.ProjectDepsFileNamePropertyName, "project.deps.json");
+
+        string projectAssetsFile = Path.Combine(projectRootElement.DirectoryPath, @"obj\project.assets.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName, projectAssetsFile);
+
+        string projectDepsFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.deps.json");
+        projectRootElement.AddProperty(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, projectDepsFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        var expectedInputFiles = new[]
+        {
+            new PredictedItem(projectAssetsFile, nameof(GeneratePublishDependencyFilePredictor)),
+        };
+        var expectedOutputFiles = new[]
+        {
+            new PredictedItem(@"obj\project.deps.json", nameof(GeneratePublishDependencyFilePredictor)),
+        };
+
+        new GeneratePublishDependencyFilePredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                expectedInputFiles,
+                null,
+                expectedOutputFiles.MakeAbsolute(projectRootElement.DirectoryPath),
+                null);
+    }
+}

--- a/src/BuildPredictionTests/Predictors/GenerateRuntimeConfigurationFilesPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/GenerateRuntimeConfigurationFilesPredictorTests.cs
@@ -1,0 +1,118 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Prediction.Predictors;
+using Xunit;
+
+namespace Microsoft.Build.Prediction.Tests.Predictors;
+
+public class GenerateRuntimeConfigurationFilesPredictorTests
+{
+    private readonly string _rootDir;
+
+    public GenerateRuntimeConfigurationFilesPredictorTests()
+    {
+        // Isolate each test into its own folder
+        _rootDir = Path.Combine(Directory.GetCurrentDirectory(), nameof(GenerateRuntimeConfigurationFilesPredictorTests), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_rootDir);
+    }
+
+    [Fact]
+    public void DoesNotGenerateRuntimeConfigurationFiles()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(_rootDir, @"src\project.csproj"));
+
+        string userRuntimeConfig = Path.Combine(projectRootElement.DirectoryPath, @"runtimeconfig.template.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.UserRuntimeConfigPropertyName, userRuntimeConfig);
+
+        string projectRuntimeConfigFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.runtimeconfig.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName, projectRuntimeConfigFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        new GenerateRuntimeConfigurationFilesPredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    [Fact]
+    public void GeneratesRuntimeConfigurationFiles()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(_rootDir, @"src\project.csproj"));
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.GenerateRuntimeConfigurationFilesPropertyName, "true");
+
+        string userRuntimeConfig = Path.Combine(projectRootElement.DirectoryPath, @"runtimeconfig.template.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.UserRuntimeConfigPropertyName, userRuntimeConfig);
+
+        string projectRuntimeConfigFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.runtimeconfig.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName, projectRuntimeConfigFilePath);
+
+        string projectRuntimeConfigDevFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.runtimeconfig.dev.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigDevFilePathPropertyName, projectRuntimeConfigDevFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        var expectedOutputFiles = new[]
+        {
+            new PredictedItem(projectRuntimeConfigFilePath, nameof(GenerateRuntimeConfigurationFilesPredictor)),
+            new PredictedItem(projectRuntimeConfigDevFilePath, nameof(GenerateRuntimeConfigurationFilesPredictor)),
+        };
+
+        new GenerateRuntimeConfigurationFilesPredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                null,
+                null,
+                expectedOutputFiles,
+                null);
+    }
+
+    [Fact]
+    public void UserRuntimeConfigExists()
+    {
+        ProjectRootElement projectRootElement = ProjectRootElement.Create(Path.Combine(_rootDir, @"src\project.csproj"));
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.GenerateRuntimeConfigurationFilesPropertyName, "true");
+
+        string userRuntimeConfig = Path.Combine(projectRootElement.DirectoryPath, @"runtimeconfig.template.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.UserRuntimeConfigPropertyName, userRuntimeConfig);
+        Directory.CreateDirectory(projectRootElement.DirectoryPath);
+        File.WriteAllText(userRuntimeConfig, "dummy");
+
+        string projectRuntimeConfigFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.runtimeconfig.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName, projectRuntimeConfigFilePath);
+
+        string projectRuntimeConfigDevFilePath = Path.Combine(projectRootElement.DirectoryPath, @"bin\x64\Debug\net8.0\project.runtimeconfig.dev.json");
+        projectRootElement.AddProperty(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigDevFilePathPropertyName, projectRuntimeConfigDevFilePath);
+
+        ProjectInstance projectInstance = TestHelpers.CreateProjectInstanceFromRootElement(projectRootElement);
+
+        var expectedInputFiles = new[]
+        {
+            new PredictedItem(userRuntimeConfig, nameof(GenerateRuntimeConfigurationFilesPredictor)),
+        };
+        var expectedOutputFiles = new[]
+        {
+            new PredictedItem(projectRuntimeConfigFilePath, nameof(GenerateRuntimeConfigurationFilesPredictor)),
+            new PredictedItem(projectRuntimeConfigDevFilePath, nameof(GenerateRuntimeConfigurationFilesPredictor)),
+        };
+
+        new GenerateRuntimeConfigurationFilesPredictor()
+            .GetProjectPredictions(projectInstance)
+            .AssertPredictions(
+                projectInstance,
+                expectedInputFiles,
+                null,
+                expectedOutputFiles,
+                null);
+    }
+}

--- a/src/BuildPredictionTests/Predictors/GetCopyToPublishDirectoryItemsGraphPredictorTests.cs
+++ b/src/BuildPredictionTests/Predictors/GetCopyToPublishDirectoryItemsGraphPredictorTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Prediction.Predictors;
@@ -49,18 +50,32 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
                 .AssertNoPredictions();
         }
 
-        [Fact]
-        public void Publish()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void Publish(bool hasRuntimeOutput)
         {
             string projectFile = Path.Combine(_rootDir, @"src\project.csproj");
             ProjectRootElement projectRootElement = ProjectRootElement.Create(projectFile);
             projectRootElement.DefaultTargets = "Publish";
-            projectRootElement.AddProperty(GetCopyToPublishDirectoryItemsGraphPredictor.PublishDirPropertyName, @"bin\Publish");
 
             const bool shouldCopy = true;
             ProjectRootElement dep1 = CreateDependencyProject("dep1", shouldCopy);
             ProjectRootElement dep2 = CreateDependencyProject("dep2", shouldCopy);
             ProjectRootElement dep3 = CreateDependencyProject("dep3", shouldCopy);
+
+            AddPropertyToAllProjects(GetCopyToPublishDirectoryItemsGraphPredictor.PublishDirPropertyName, @"bin\Publish");
+            AddPropertyToAllProjects(GeneratePublishDependencyFilePredictor.ProjectDepsFileNamePropertyName, "$(MSBuildProjectName).deps.json");
+            AddPropertyToAllProjects(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName, @"$(MSBuildProjectDirectory)\bin\$(MSBuildProjectName).deps.json");
+            AddPropertyToAllProjects(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName, @"$(MSBuildProjectDirectory)\bin\$(MSBuildProjectName).runtimeconfig.json");
+            AddPropertyToAllProjects(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigDevFilePathPropertyName, @"$(MSBuildProjectDirectory)\bin\$(MSBuildProjectName).runtimeconfig.dev.json");
+
+            if (hasRuntimeOutput)
+            {
+                AddPropertyToAllProjects(GetCopyToOutputDirectoryItemsGraphPredictor.HasRuntimeOutputPropertyName, "true");
+                AddPropertyToAllProjects(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName, "true");
+                AddPropertyToAllProjects(GenerateRuntimeConfigurationFilesPredictor.GenerateRuntimeConfigurationFilesPropertyName, "true");
+            }
 
             // The main project depends on 1 and 2; 2 depends on 3; 3 depends on 1. Note that this should *not* be transitive
             projectRootElement.AddItem("ProjectReference", @"..\dep1\dep1.proj");
@@ -73,8 +88,8 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
             dep2.Save();
             dep3.Save();
 
-            var expectedInputFiles = new[]
-            {
+            List<PredictedItem> expectedInputFiles =
+            [
                 new PredictedItem(@"dep1\dep1.xml", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"dep1\dep1.resx", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"dep1\dep1.cs", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
@@ -83,10 +98,10 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
                 new PredictedItem(@"dep2\dep2.resx", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"dep2\dep2.cs", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"dep2\dep2.txt", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
-            };
+            ];
 
-            var expectedOutputFiles = new[]
-            {
+            List<PredictedItem> expectedOutputFiles =
+            [
                 new PredictedItem(@"src\bin\Publish\dep1.xml", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"src\bin\Publish\dep1.resx", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"src\bin\Publish\dep1.cs", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
@@ -95,7 +110,30 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
                 new PredictedItem(@"src\bin\Publish\dep2.resx", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"src\bin\Publish\dep2.cs", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
                 new PredictedItem(@"src\bin\Publish\dep2.txt", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
-            };
+            ];
+
+            if (hasRuntimeOutput)
+            {
+                expectedInputFiles.AddRange(
+                    [
+                        new PredictedItem(@"src\bin\project.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\project.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"dep1\bin\dep1.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"dep1\bin\dep1.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"dep2\bin\dep2.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"dep2\bin\dep2.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                    ]);
+
+                expectedOutputFiles.AddRange(
+                    [
+                        new PredictedItem(@"src\bin\Publish\project.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\Publish\project.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\Publish\dep1.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\Publish\dep1.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\Publish\dep2.deps.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                        new PredictedItem(@"src\bin\Publish\dep2.runtimeconfig.json", nameof(GetCopyToPublishDirectoryItemsGraphPredictor)),
+                    ]);
+            }
 
             new GetCopyToPublishDirectoryItemsGraphPredictor()
                 .GetProjectPredictions(projectFile)
@@ -105,6 +143,14 @@ namespace Microsoft.Build.Prediction.Tests.Predictors
                     null,
                     expectedOutputFiles,
                     null);
+
+            void AddPropertyToAllProjects(string propertyName, string propertyValue)
+            {
+                projectRootElement.AddProperty(propertyName, propertyValue);
+                dep1.AddProperty(propertyName, propertyValue);
+                dep2.AddProperty(propertyName, propertyValue);
+                dep3.AddProperty(propertyName, propertyValue);
+            }
         }
 
         [Fact]


### PR DESCRIPTION
This change adds the following predictors:
* `GenerateBuildDependencyFilePredictor` - Makes predictions based on the GenerateBuildDependencyFile target (`<project>.deps.json` file)
* `GeneratePublishDependencyFilePredictor` - Makes predictions based on the GeneratePublishDependencyFile target. (`<project>.deps.json` file, when publishing)
* `GenerateRuntimeConfigurationFilesPredictor` - Makes predictions based on the GenerateRuntimeConfigurationFiles target. (`<project>.runtimeconfig.json` and `<project>.runtimeconfig.dev.json` files)

As well as adds the copying of those files in referencing projects to `GetCopyToOutputDirectoryItemsGraphPredictor` and `GetCopyToPublishDirectoryItemsGraphPredictor`.