### PR TITLE
Add defensive checks to deps.json and runtimeconfig.json predictions

### DIFF
--- a/src/BuildPrediction/Predictors/GenerateBuildDependencyFilePredictor.cs
+++ b/src/BuildPrediction/Predictors/GenerateBuildDependencyFilePredictor.cs
@@ -25,7 +25,16 @@ public sealed class GenerateBuildDependencyFilePredictor : IProjectPredictor
             return;
         }
 
-        predictionReporter.ReportInputFile(projectInstance.GetPropertyValue(ProjectAssetsFilePropertyName));
-        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectDepsFilePathPropertyName));
+        string projectAssetsFilePropertyName = projectInstance.GetPropertyValue(ProjectAssetsFilePropertyName);
+        if (!string.IsNullOrEmpty(projectAssetsFilePropertyName))
+        {
+            predictionReporter.ReportInputFile(projectAssetsFilePropertyName);
+        }
+
+        string projectDepsFilePath = projectInstance.GetPropertyValue(ProjectDepsFilePathPropertyName);
+        if (!string.IsNullOrEmpty(projectDepsFilePath))
+        {
+            predictionReporter.ReportOutputFile(projectDepsFilePath);
+        }
     }
 }

--- a/src/BuildPrediction/Predictors/GeneratePublishDependencyFilePredictor.cs
+++ b/src/BuildPrediction/Predictors/GeneratePublishDependencyFilePredictor.cs
@@ -37,13 +37,20 @@ public sealed class GeneratePublishDependencyFilePredictor : IProjectPredictor
             return;
         }
 
-        predictionReporter.ReportInputFile(projectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName));
+        string projectAssetsFilePropertyName = projectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.ProjectAssetsFilePropertyName);
+        if (!string.IsNullOrEmpty(projectAssetsFilePropertyName))
+        {
+            predictionReporter.ReportInputFile(projectAssetsFilePropertyName);
+        }
 
         string publishDepsFilePath = GetEffectivePublishDepsFilePath(projectInstance);
-        string intermediateDepsFilePath = publishDepsFilePath is not null
+        string intermediateDepsFilePath = !string.IsNullOrEmpty(publishDepsFilePath)
             ? publishDepsFilePath
             : projectInstance.GetPropertyValue(IntermediateOutputPathPropertyName) + projectInstance.GetPropertyValue(ProjectDepsFileNamePropertyName);
-        predictionReporter.ReportOutputFile(intermediateDepsFilePath);
+        if (!string.IsNullOrEmpty(intermediateDepsFilePath))
+        {
+            predictionReporter.ReportOutputFile(intermediateDepsFilePath);
+        }
 
         // Note: GetCopyToPublishDirectoryItemsGraphPredictor will predict the final (published) location for the publish deps file since that's the target which does that copy.
     }

--- a/src/BuildPrediction/Predictors/GenerateRuntimeConfigurationFilesPredictor.cs
+++ b/src/BuildPrediction/Predictors/GenerateRuntimeConfigurationFilesPredictor.cs
@@ -28,13 +28,25 @@ public sealed class GenerateRuntimeConfigurationFilesPredictor : IProjectPredict
         }
 
         string userRuntimeConfig = projectInstance.GetPropertyValue(UserRuntimeConfigPropertyName);
-        string userRuntimeConfigFullPath = Path.Combine(projectInstance.Directory, userRuntimeConfig);
-        if (File.Exists(userRuntimeConfigFullPath))
+        if (!string.IsNullOrEmpty(userRuntimeConfig))
         {
-            predictionReporter.ReportInputFile(userRuntimeConfigFullPath);
+            string userRuntimeConfigFullPath = Path.Combine(projectInstance.Directory, userRuntimeConfig);
+            if (File.Exists(userRuntimeConfigFullPath))
+            {
+                predictionReporter.ReportInputFile(userRuntimeConfigFullPath);
+            }
         }
 
-        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectRuntimeConfigFilePathPropertyName));
-        predictionReporter.ReportOutputFile(projectInstance.GetPropertyValue(ProjectRuntimeConfigDevFilePathPropertyName));
+        string projectRuntimeConfigFilePath = projectInstance.GetPropertyValue(ProjectRuntimeConfigFilePathPropertyName);
+        if (!string.IsNullOrEmpty(projectRuntimeConfigFilePath))
+        {
+            predictionReporter.ReportOutputFile(projectRuntimeConfigFilePath);
+        }
+
+        string projectRuntimeConfigDevFilePath = projectInstance.GetPropertyValue(ProjectRuntimeConfigDevFilePathPropertyName);
+        if (!string.IsNullOrEmpty(projectRuntimeConfigDevFilePath))
+        {
+            predictionReporter.ReportOutputFile(projectRuntimeConfigDevFilePath);
+        }
     }
 }

--- a/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
@@ -71,19 +71,28 @@ namespace Microsoft.Build.Prediction.Predictors
                         if (dependency.ProjectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.GenerateDependencyFilePropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
                         {
                             string projectDepsFilePath = dependency.ProjectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName);
-                            predictionReporter.ReportInputFile(projectDepsFilePath);
-                            predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectDepsFilePath)));
+                            if (!string.IsNullOrEmpty(projectDepsFilePath))
+                            {
+                                predictionReporter.ReportInputFile(projectDepsFilePath);
+                                predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectDepsFilePath)));
+                            }
                         }
 
                         if (dependency.ProjectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPredictor.GenerateRuntimeConfigurationFilesPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
                         {
                             string projectRuntimeConfigFilePath = dependency.ProjectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName);
-                            predictionReporter.ReportInputFile(projectRuntimeConfigFilePath);
-                            predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+                            if (!string.IsNullOrEmpty(projectRuntimeConfigFilePath))
+                            {
+                                predictionReporter.ReportInputFile(projectRuntimeConfigFilePath);
+                                predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+                            }
 
                             string projectRuntimeConfigDevFilePath = dependency.ProjectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigDevFilePathPropertyName);
-                            predictionReporter.ReportInputFile(projectRuntimeConfigDevFilePath);
-                            predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectRuntimeConfigDevFilePath)));
+                            if (!string.IsNullOrEmpty(projectRuntimeConfigDevFilePath))
+                            {
+                                predictionReporter.ReportInputFile(projectRuntimeConfigDevFilePath);
+                                predictionReporter.ReportOutputFile(Path.Combine(outDir, Path.GetFileName(projectRuntimeConfigDevFilePath)));
+                            }
                         }
                     }
                 }

--- a/src/BuildPrediction/Predictors/GetCopyToPublishDirectoryItemsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/GetCopyToPublishDirectoryItemsGraphPredictor.cs
@@ -89,13 +89,16 @@ namespace Microsoft.Build.Prediction.Predictors
                     if (GeneratePublishDependencyFilePredictor.ShouldUseBuildDependencyFile(projectInstance))
                     {
                         string projectDepsFilePath = projectInstance.GetPropertyValue(GenerateBuildDependencyFilePredictor.ProjectDepsFilePathPropertyName);
-                        predictionReporter.ReportInputFile(projectDepsFilePath);
-                        predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectDepsFilePath)));
+                        if (!string.IsNullOrEmpty(projectDepsFilePath))
+                        {
+                            predictionReporter.ReportInputFile(projectDepsFilePath);
+                            predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectDepsFilePath)));
+                        }
                     }
                     else
                     {
                         string publishDepsFilePath = GeneratePublishDependencyFilePredictor.GetEffectivePublishDepsFilePath(projectInstance);
-                        if (publishDepsFilePath is not null)
+                        if (!string.IsNullOrEmpty(publishDepsFilePath))
                         {
                             predictionReporter.ReportInputFile(publishDepsFilePath);
                             predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(publishDepsFilePath)));
@@ -106,8 +109,11 @@ namespace Microsoft.Build.Prediction.Predictors
                 if (projectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPredictor.GenerateRuntimeConfigurationFilesPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase))
                 {
                     string projectRuntimeConfigFilePath = projectInstance.GetPropertyValue(GenerateRuntimeConfigurationFilesPredictor.ProjectRuntimeConfigFilePathPropertyName);
-                    predictionReporter.ReportInputFile(projectRuntimeConfigFilePath);
-                    predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+                    if (!string.IsNullOrEmpty(projectRuntimeConfigFilePath))
+                    {
+                        predictionReporter.ReportInputFile(projectRuntimeConfigFilePath);
+                        predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+                    }
                 }
             }
         }


### PR DESCRIPTION
Based on additional testing I found that `*.runtimeconfig.dev.json` files are no longer produced as of .NET SDK 6:

```xml
  <PropertyGroup Condition="'$(GenerateRuntimeConfigDevFile)' == ''">
    <GenerateRuntimeConfigDevFile>true</GenerateRuntimeConfigDevFile>
    <!-- Post-net6.0, stop generating *.runtimeconfig.dev.json files to reduce probing paths. -->
    <!-- https://github.com/dotnet/sdk/issues/16818 -->
    <GenerateRuntimeConfigDevFile Condition="'$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '6.0'))">false</GenerateRuntimeConfigDevFile>
  </PropertyGroup>
```

I added defensive checks everywhere though just in case anything happens to be unexpectedly missing.