### PR TITLE
Fix nullref in GetCopyToPublishDirectoryItemsGraphPredictor

### DIFF
--- a/src/BuildPrediction/Predictors/GetCopyToPublishDirectoryItemsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/GetCopyToPublishDirectoryItemsGraphPredictor.cs
@@ -92,7 +92,11 @@ namespace Microsoft.Build.Prediction.Predictors
                         if (!string.IsNullOrEmpty(projectDepsFilePath))
                         {
                             predictionReporter.ReportInputFile(projectDepsFilePath);
-                            predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectDepsFilePath)));
+
+                            if (!string.IsNullOrEmpty(publishDir))
+                            {
+                                predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectDepsFilePath)));
+                            }
                         }
                     }
                     else
@@ -101,7 +105,11 @@ namespace Microsoft.Build.Prediction.Predictors
                         if (!string.IsNullOrEmpty(publishDepsFilePath))
                         {
                             predictionReporter.ReportInputFile(publishDepsFilePath);
-                            predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(publishDepsFilePath)));
+
+                            if (!string.IsNullOrEmpty(publishDir))
+                            {
+                                predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(publishDepsFilePath)));
+                            }
                         }
                     }
                 }
@@ -112,7 +120,11 @@ namespace Microsoft.Build.Prediction.Predictors
                     if (!string.IsNullOrEmpty(projectRuntimeConfigFilePath))
                     {
                         predictionReporter.ReportInputFile(projectRuntimeConfigFilePath);
-                        predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+
+                        if (!string.IsNullOrEmpty(publishDir))
+                        {
+                            predictionReporter.ReportOutputFile(Path.Combine(publishDir, Path.GetFileName(projectRuntimeConfigFilePath)));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is happening for sfproj projects because in `ServiceFabricCopyFilesToPublishDirectoryGraphPredictor`, it passes a null `publishDir` to `GetCopyToPublishDirectoryItemsGraphPredictor`:

```cs
// A service fabric project publishes its dependencies with its own publish dir. However, we're not providing the publish dir
// since that requires cracking open the service manifest to find the correct subdir. Instead we'll just predict the directory.
foreach (ProjectGraphNode projectReference in projectGraphNode.ProjectReferences)
{
    GetCopyToPublishDirectoryItemsGraphPredictor.PredictInputsAndOutputs(projectReference, publishDir: null, predictionReporter);
}
```