### PR TITLE
Switch from snupkg to embedded PDBs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,8 +54,7 @@
   <PropertyGroup>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <!-- Artifacts -->

--- a/src/BuildPrediction/Microsoft.Build.Prediction.csproj
+++ b/src/BuildPrediction/Microsoft.Build.Prediction.csproj
@@ -23,10 +23,4 @@
   <ItemGroup>
     <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
-  <!-- This needs to evaluate in a target since the package version is calculated dynamically in GetBuildVersion -->
-  <Target Name="GetSnupkgSignNuGetPackFiles" BeforeTargets="SignNuGetPackage" AfterTargets="GetBuildVersion">
-    <ItemGroup>
-      <SignNuGetPackFiles Include="$(PackageOutputPath)\$(AssemblyName).$(PackageVersion).snupkg" />
-    </ItemGroup>
-  </Target>
 </Project>


### PR DESCRIPTION
Switch from snupkg symbol packages to embedded PDBs for simpler debugging experience.

- Replace `IncludeSymbols`/`SymbolPackageFormat=snupkg` with `DebugType=embedded` in `Directory.Build.props`
- Remove dead `GetSnupkgSignNuGetPackFiles` signing target from library csproj