### PR TITLE
Small perf improvements: Correct lock granularity and cache path normalization in DefaultProjectPredictionCollector

### DIFF
--- a/src/BuildPrediction/DefaultProjectPredictionCollector.cs
+++ b/src/BuildPrediction/DefaultProjectPredictionCollector.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Build.Prediction
         private readonly Dictionary<string, PredictedItem> _outputFilesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
         private readonly Dictionary<string, PredictedItem> _outputDirectoriesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
 
-        // Cache for Path.GetFullPath results to avoid redundant filesystem calls for repeated relative paths.
-        private readonly ConcurrentDictionary<string, string> _absolutePathCache = new ConcurrentDictionary<string, string>(PathComparer.Instance);
+        // Cache for Path.GetFullPath results to avoid repeated string allocations for the same relative paths.
+        private readonly ConcurrentDictionary<(string Directory, string Path), string> _absolutePathCache = new ConcurrentDictionary<(string, string), string>();
 
         public DefaultProjectPredictionCollector()
         {
@@ -45,11 +45,11 @@ namespace Microsoft.Build.Prediction
 
         private void AddPredictedItem(Dictionary<string, PredictedItem> items, string path, ProjectInstance projectInstance, string predictorName)
         {
-            // Make the path absolute if needed, using a cache to avoid redundant Path.GetFullPath calls.
+            // Make the path absolute if needed, using a cache to avoid repeated string allocations.
             if (!Path.IsPathRooted(path))
             {
-                string cacheKey = string.Concat(projectInstance.Directory, "|", path);
-                path = _absolutePathCache.GetOrAdd(cacheKey, _ => Path.GetFullPath(Path.Combine(projectInstance.Directory, path)));
+                var cacheKey = (projectInstance.Directory, path);
+                path = _absolutePathCache.GetOrAdd(cacheKey, static k => Path.GetFullPath(Path.Combine(k.Directory, k.Path)));
             }
 
             // Get or add the item and record the predictor in a single lock acquisition.

--- a/src/BuildPrediction/DefaultProjectPredictionCollector.cs
+++ b/src/BuildPrediction/DefaultProjectPredictionCollector.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Build.Prediction
         private readonly Dictionary<string, PredictedItem> _outputDirectoriesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
 
         // Cache for Path.GetFullPath results to avoid repeated string allocations for the same relative paths.
+        // Path.GetFullPath is pure string manipulation on .NET Core and calls the GetFullPathName API on
+        // .NET Framework (which also does not perform I/O). The cache saves the allocation cost of
+        // Path.Combine + Path.GetFullPath when the same relative path is reported by multiple predictors.
         private readonly ConcurrentDictionary<(string Directory, string Path), string> _absolutePathCache = new ConcurrentDictionary<(string, string), string>();
 
         public DefaultProjectPredictionCollector()
@@ -45,22 +48,27 @@ namespace Microsoft.Build.Prediction
 
         private void AddPredictedItem(Dictionary<string, PredictedItem> items, string path, ProjectInstance projectInstance, string predictorName)
         {
-            // Make the path absolute if needed, using a cache to avoid repeated string allocations.
+            // Make the path absolute if needed.
             if (!Path.IsPathRooted(path))
             {
                 var cacheKey = (projectInstance.Directory, path);
                 path = _absolutePathCache.GetOrAdd(cacheKey, static k => Path.GetFullPath(Path.Combine(k.Directory, k.Path)));
             }
 
-            // Get or add the item and record the predictor in a single lock acquisition.
+            // Get the existing item, or add a new one if needed.
+            PredictedItem item;
             lock (items)
             {
-                if (!items.TryGetValue(path, out PredictedItem item))
+                if (!items.TryGetValue(path, out item))
                 {
                     item = new PredictedItem(path);
                     items.Add(path, item);
                 }
+            }
 
+            // Record the predictor, locking on the item to protect its HashSet.
+            lock (item)
+            {
                 item.AddPredictedBy(predictorName);
             }
         }

--- a/src/BuildPrediction/DefaultProjectPredictionCollector.cs
+++ b/src/BuildPrediction/DefaultProjectPredictionCollector.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Execution;
@@ -16,6 +17,9 @@ namespace Microsoft.Build.Prediction
         private readonly Dictionary<string, PredictedItem> _inputsDirectoriesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
         private readonly Dictionary<string, PredictedItem> _outputFilesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
         private readonly Dictionary<string, PredictedItem> _outputDirectoriesByPath = new Dictionary<string, PredictedItem>(PathComparer.Instance);
+
+        // Cache for Path.GetFullPath results to avoid redundant filesystem calls for repeated relative paths.
+        private readonly ConcurrentDictionary<string, string> _absolutePathCache = new ConcurrentDictionary<string, string>(PathComparer.Instance);
 
         public DefaultProjectPredictionCollector()
         {
@@ -39,28 +43,24 @@ namespace Microsoft.Build.Prediction
 
         public void AddOutputDirectory(string path, ProjectInstance projectInstance, string predictorName) => AddPredictedItem(_outputDirectoriesByPath, path, projectInstance, predictorName);
 
-        private static void AddPredictedItem(Dictionary<string, PredictedItem> items, string path, ProjectInstance projectInstance, string predictorName)
+        private void AddPredictedItem(Dictionary<string, PredictedItem> items, string path, ProjectInstance projectInstance, string predictorName)
         {
-            // Make the path absolute if needed.
+            // Make the path absolute if needed, using a cache to avoid redundant Path.GetFullPath calls.
             if (!Path.IsPathRooted(path))
             {
-                path = Path.GetFullPath(Path.Combine(projectInstance.Directory, path));
+                string cacheKey = string.Concat(projectInstance.Directory, "|", path);
+                path = _absolutePathCache.GetOrAdd(cacheKey, _ => Path.GetFullPath(Path.Combine(projectInstance.Directory, path)));
             }
 
-            // Get the existing item, or add a new one if needed.
-            PredictedItem item;
+            // Get or add the item and record the predictor in a single lock acquisition.
             lock (items)
             {
-                if (!items.TryGetValue(path, out item))
+                if (!items.TryGetValue(path, out PredictedItem item))
                 {
                     item = new PredictedItem(path);
                     items.Add(path, item);
                 }
-            }
 
-            // Add the predictor
-            lock (items)
-            {
                 item.AddPredictedBy(predictorName);
             }
         }

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Prediction
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectPredictor> AllProjectPredictors { get; } = new IProjectPredictor[]
+        public static IReadOnlyCollection<IProjectPredictor> AllProjectPredictors => new IProjectPredictor[]
         {
             new AvailableItemNameItemsPredictor(),
             new ContentItemsPredictor(),
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Prediction
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectGraphPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectGraphPredictor> AllProjectGraphPredictors { get; } = new IProjectGraphPredictor[]
+        public static IReadOnlyCollection<IProjectGraphPredictor> AllProjectGraphPredictors => new IProjectGraphPredictor[]
         {
             new ProjectFileAndImportsGraphPredictor(),
             new GetCopyToOutputDirectoryItemsGraphPredictor(),

--- a/src/BuildPrediction/ProjectPredictors.cs
+++ b/src/BuildPrediction/ProjectPredictors.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Build.Prediction
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectPredictor> AllProjectPredictors => new IProjectPredictor[]
+        public static IReadOnlyCollection<IProjectPredictor> AllProjectPredictors { get; } = new IProjectPredictor[]
         {
             new AvailableItemNameItemsPredictor(),
             new ContentItemsPredictor(),
@@ -134,7 +134,7 @@ namespace Microsoft.Build.Prediction
         /// </list>
         /// </remarks>
         /// <returns>A collection of <see cref="IProjectGraphPredictor"/>.</returns>
-        public static IReadOnlyCollection<IProjectGraphPredictor> AllProjectGraphPredictors => new IProjectGraphPredictor[]
+        public static IReadOnlyCollection<IProjectGraphPredictor> AllProjectGraphPredictors { get; } = new IProjectGraphPredictor[]
         {
             new ProjectFileAndImportsGraphPredictor(),
             new GetCopyToOutputDirectoryItemsGraphPredictor(),


### PR DESCRIPTION
## Summary

Two fixes to `DefaultProjectPredictionCollector.AddPredictedItem`:

### 1. Correct lock granularity for `AddPredictedBy`

The original code acquired `lock(items)` (the dictionary) twice per call — once for the get/add, and again for `AddPredictedBy`. The second lock was likely intended to be `lock(item)` to protect the `PredictedItem`'s internal `HashSet`.

This fix separates the two concerns:
- `lock(items)` — protects the dictionary lookup/insertion
- `lock(item)` — protects the `PredictedItem.AddPredictedBy` HashSet mutation

This also reduces contention under parallel workloads since the dictionary is no longer held while updating an individual item's predictor set.

### 2. Cache `Path.GetFullPath` results for relative paths

Added a `ConcurrentDictionary<(string, string), string>` cache to avoid repeated string allocations when the same relative path is reported by multiple predictors. Uses a `ValueTuple` key and a `static` lambda to avoid closure allocations.

Note: `Path.GetFullPath` is pure string manipulation on .NET Core and calls the `GetFullPathName` Win32 API on .NET Framework (which also does not perform I/O). The cache saves the allocation cost of `Path.Combine` + `Path.GetFullPath` for duplicate relative paths.