### PR TITLE
Memoize copy-to-output-directory item filtering in graph predictor to improve perf

### DIFF
--- a/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
+++ b/src/BuildPrediction/Predictors/GetCopyToOutputDirectoryItemsGraphPredictor.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using Microsoft.Build.Execution;
@@ -19,6 +20,21 @@ namespace Microsoft.Build.Prediction.Predictors
         internal const string MSBuildCopyContentTransitivelyPropertyName = "MSBuildCopyContentTransitively";
         internal const string HasRuntimeOutputPropertyName = "HasRuntimeOutput";
 
+        private static readonly string[] CopyItemNames = new[]
+        {
+            ContentItemsPredictor.ContentItemName,
+            ContentItemsPredictor.ContentWithTargetPathItemName,
+            EmbeddedResourceItemsPredictor.EmbeddedResourceItemName,
+            CompileItemsPredictor.CompileItemName,
+            NoneItemsPredictor.NoneItemName,
+            XamlAppDefPredictor.XamlAppDefItemName,
+        };
+
+        // Cache of filtered copy-to-output-directory items per ProjectInstance.
+        // Keyed on ProjectInstance identity since each graph execution creates unique instances.
+        // Uses Lazy<> to ensure the filtering work runs exactly once per dependency under contention.
+        private readonly ConcurrentDictionary<ProjectInstance, Lazy<CopyItemResult[]>> _copyItemCache = new();
+
         /// <inheritdoc/>
         public void PredictInputsAndOutputs(ProjectGraphNode projectGraphNode, ProjectPredictionReporter predictionReporter)
         {
@@ -27,7 +43,27 @@ namespace Microsoft.Build.Prediction.Predictors
             PredictInputsAndOutputs(projectGraphNode, outDir, predictionReporter, visitedNodes);
         }
 
-        private static void PredictInputsAndOutputs(
+        private static CopyItemResult[] BuildCopyItemsCore(ProjectInstance projectInstance)
+        {
+            var results = new List<CopyItemResult>();
+
+            foreach (string itemName in CopyItemNames)
+            {
+                foreach (ProjectItemInstance item in projectInstance.GetItems(itemName))
+                {
+                    if (item.ShouldCopyToOutputDirectory())
+                    {
+                        string inputPath = Path.Combine(projectInstance.Directory, item.EvaluatedInclude);
+                        string targetPath = item.GetTargetPath();
+                        results.Add(new CopyItemResult(inputPath, targetPath));
+                    }
+                }
+            }
+
+            return results.ToArray();
+        }
+
+        private void PredictInputsAndOutputs(
             ProjectGraphNode projectGraphNode,
             string outDir,
             ProjectPredictionReporter predictionReporter,
@@ -55,15 +91,17 @@ namespace Microsoft.Build.Prediction.Predictors
                         PredictInputsAndOutputs(dependency, outDir, predictionReporter, visitedNodes);
                     }
 
-                    // Process each item type considered in GetCopyToOutputDirectoryItems. Yes, Compile is considered.
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, ContentItemsPredictor.ContentItemName, outDir, predictionReporter);
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, ContentItemsPredictor.ContentWithTargetPathItemName, outDir, predictionReporter);
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, EmbeddedResourceItemsPredictor.EmbeddedResourceItemName, outDir, predictionReporter);
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, CompileItemsPredictor.CompileItemName, outDir, predictionReporter);
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, NoneItemsPredictor.NoneItemName, outDir, predictionReporter);
+                    // Report cached copy-to-output-directory items for this dependency.
+                    CopyItemResult[] cachedItems = GetCopyItems(dependency.ProjectInstance);
+                    foreach (CopyItemResult copyItem in cachedItems)
+                    {
+                        predictionReporter.ReportInputFile(copyItem.InputPath);
 
-                    // Process each item type considered in GetCopyToOutputDirectoryXamlAppDefs
-                    ReportCopyToOutputDirectoryItemsAsInputs(dependency.ProjectInstance, XamlAppDefPredictor.XamlAppDefItemName, outDir, predictionReporter);
+                        if (!string.IsNullOrEmpty(outDir) && !string.IsNullOrEmpty(copyItem.TargetPath))
+                        {
+                            predictionReporter.ReportOutputFile(Path.Combine(outDir, copyItem.TargetPath));
+                        }
+                    }
 
                     // Process items added by AddDepsJsonAndRuntimeConfigToCopyItemsForReferencingProjects
                     bool hasRuntimeOutput = dependency.ProjectInstance.GetPropertyValue(HasRuntimeOutputPropertyName).Equals("true", StringComparison.OrdinalIgnoreCase);
@@ -123,29 +161,24 @@ namespace Microsoft.Build.Prediction.Predictors
             }
         }
 
-        private static void ReportCopyToOutputDirectoryItemsAsInputs(
-            ProjectInstance projectInstance,
-            string itemName,
-            string outDir,
-            ProjectPredictionReporter predictionReporter)
+        private CopyItemResult[] GetCopyItems(ProjectInstance projectInstance)
         {
-            foreach (ProjectItemInstance item in projectInstance.GetItems(itemName))
-            {
-                if (item.ShouldCopyToOutputDirectory())
-                {
-                    // The item will be relative to the project instance passed in, not the current project instance, so make the path absolute.
-                    predictionReporter.ReportInputFile(Path.Combine(projectInstance.Directory, item.EvaluatedInclude));
+            return _copyItemCache.GetOrAdd(
+                projectInstance,
+                static pi => new Lazy<CopyItemResult[]>(() => BuildCopyItemsCore(pi))).Value;
+        }
 
-                    if (!string.IsNullOrEmpty(outDir))
-                    {
-                        string targetPath = item.GetTargetPath();
-                        if (!string.IsNullOrEmpty(targetPath))
-                        {
-                            predictionReporter.ReportOutputFile(Path.Combine(outDir, targetPath));
-                        }
-                    }
-                }
+        private readonly struct CopyItemResult
+        {
+            public CopyItemResult(string inputPath, string targetPath)
+            {
+                InputPath = inputPath;
+                TargetPath = targetPath;
             }
+
+            public string InputPath { get; }
+
+            public string TargetPath { get; }
         }
     }
 }


### PR DESCRIPTION
Cache the filtered `CopyToOutputDirectory` items per dependency ProjectInstance in `GetCopyToOutputDirectoryItemsGraphPredictor`. When multiple root nodes share transitive dependencies (common in large graphs), the same dependency's items were being filtered repeatedly across 6 item types.

The cache uses `ConcurrentDictionary<ProjectInstance, Lazy<CopyItemResult[]>>`:
- `ConcurrentDictionary` for thread-safe access from parallel graph node processing
- `Lazy<>` ensures the filtering work runs exactly once per dependency under contention
- Results stored as immutable arrays of `(InputPath, TargetPath)` structs
- Output paths (which depend on the caller's OutDir) are computed at report time