### PR TITLE
Add MaxDegreeOfParallelismPerProject option

### DIFF
--- a/src/BuildPrediction/ProjectGraphPredictionExecutor.cs
+++ b/src/BuildPrediction/ProjectGraphPredictionExecutor.cs
@@ -80,15 +80,16 @@ namespace Microsoft.Build.Prediction
             {
                 foreach (var projectNode in projectGraph.ProjectNodes)
                 {
-                    ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector);
+                    ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector, _options.MaxDegreeOfParallelismPerProject);
                 }
             }
             else
             {
+                int maxDegreeOfParallelismPerProject = _options.MaxDegreeOfParallelismPerProject;
                 Parallel.ForEach(
                     projectGraph.ProjectNodes.ToArray(),
                     new ParallelOptions() { MaxDegreeOfParallelism = _options.MaxDegreeOfParallelism },
-                    projectNode => ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector));
+                    projectNode => ExecuteAllPredictors(projectNode, _projectPredictors, _projectGraphPredictors, projectPredictionCollector, maxDegreeOfParallelismPerProject));
             }
         }
 
@@ -96,12 +97,13 @@ namespace Microsoft.Build.Prediction
             ProjectGraphNode projectGraphNode,
             ValueAndTypeName<IProjectPredictor>[] projectPredictors,
             ValueAndTypeName<IProjectGraphPredictor>[] projectGraphPredictors,
-            IProjectPredictionCollector projectPredictionCollector)
+            IProjectPredictionCollector projectPredictionCollector,
+            int maxDegreeOfParallelismPerProject)
         {
             ProjectInstance projectInstance = projectGraphNode.ProjectInstance;
 
-            // Run the project predictors. Use single-threaded prediction since we're already parallelizing on projects.
-            ProjectPredictionExecutor.ExecuteProjectPredictors(projectInstance, projectPredictors, projectPredictionCollector, maxDegreeOfParallelism: 1);
+            // Run the project predictors.
+            ProjectPredictionExecutor.ExecuteProjectPredictors(projectInstance, projectPredictors, projectPredictionCollector, maxDegreeOfParallelismPerProject);
 
             // Run the graph predictors
             for (var i = 0; i < projectGraphPredictors.Length; i++)

--- a/src/BuildPrediction/ProjectPredictionOptions.cs
+++ b/src/BuildPrediction/ProjectPredictionOptions.cs
@@ -17,5 +17,22 @@ namespace Microsoft.Build.Prediction
         /// If the caller of <see cref="ProjectPredictionExecutor"/> is parallelizing across projects, it's recommended to set this to 1 to avoid over-scheduling.
         /// </remarks>
         public int MaxDegreeOfParallelism { get; set; } = Environment.ProcessorCount;
+
+        /// <summary>
+        /// Gets or sets the max degree of parallelism to use for running predictors within a single project during graph prediction.
+        /// Defaults to 1, meaning predictors for each project run sequentially.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// When using <see cref="ProjectGraphPredictionExecutor"/>, projects are processed in parallel (controlled by <see cref="MaxDegreeOfParallelism"/>),
+        /// and predictors within each project are processed with this level of parallelism. The total thread usage may be up to
+        /// <see cref="MaxDegreeOfParallelism"/> × <see cref="MaxDegreeOfParallelismPerProject"/>, so care should be taken to avoid over-subscription.
+        /// </para>
+        /// <para>
+        /// Increasing this value can help when individual projects are bottlenecks (e.g. projects with many items that take a long time to predict),
+        /// but it assumes all predictors are thread-safe. Built-in predictors are thread-safe, but custom predictors should be verified.
+        /// </para>
+        /// </remarks>
+        public int MaxDegreeOfParallelismPerProject { get; set; } = 1;
     }
 }


### PR DESCRIPTION
Add a new option to control parallelism of predictors within a single project during graph prediction. Previously hardcoded to 1, this can now be increased for projects that are bottlenecks (e.g. projects with many items running 38+ sequential predictors).

The total thread usage may be up to `MaxDegreeOfParallelism` x `MaxDegreeOfParallelismPerProject`, so care should be taken to avoid over-subscription. Default is 1 to preserve existing behavior.