### PR TITLE
Initialize MSBuild for tests

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,9 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
     <PackageVersion Include="Microsoft.Build" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MSBuildPackageVersion)" />
+    <PackageVersion Include="Microsoft.Build.Locator" Version="1.11.2" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MSBuildPackageVersion)" />
+    <PackageVersion Include="Microsoft.NET.StringTools" Version="$(MSBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.analyzers" Version="1.23.0" />

--- a/src/BuildPredictionTests/Microsoft.Build.Prediction.Tests.csproj
+++ b/src/BuildPredictionTests/Microsoft.Build.Prediction.Tests.csproj
@@ -9,7 +9,14 @@
     <ProjectReference Include="..\BuildPrediction\Microsoft.Build.Prediction.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Locator" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <!-- MSBuild 18 uses Immutable 10 APIs when loaded into the .NET Framework test host. -->
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.0" PrivateAssets="all" Condition=" '$(TargetFrameworkIdentifier)' == '.NETFramework' " />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.analyzers" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/src/BuildPredictionTests/TestPipelineStartup.cs
+++ b/src/BuildPredictionTests/TestPipelineStartup.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Threading.Tasks;
+using Microsoft.Build.Locator;
+using Xunit.Sdk;
+using Xunit.v3;
+
+[assembly: TestPipelineStartup(typeof(Microsoft.Build.Prediction.Tests.TestPipelineStartup))]
+
+namespace Microsoft.Build.Prediction.Tests
+{
+    internal sealed class TestPipelineStartup : ITestPipelineStartup
+    {
+        public ValueTask StartAsync(IMessageSink diagnosticMessageSink)
+        {
+            MSBuildLocator.RegisterDefaults();
+            return default;
+        }
+
+        public ValueTask StopAsync() => default;
+    }
+}


### PR DESCRIPTION
## Summary

This fixes the Windows net472 CI failure by initializing MSBuild before xUnit discovery, so the test host loads a complete installed `Current` toolset instead of falling back to the incomplete test-host defaults that triggered `ToolsVersion "Current"` errors.

The test project now treats MSBuild packages as compile-only references. The net472 host also gets the Immutable 10 compatibility dependency needed to load MSBuild 18 on .NET Framework.

## Validation

- Workflow-equivalent restore, build, and test:
  - net472: 214/214 passed
  - net8.0: 209/209 passed
  - net10.0: 209/209 passed
- Clean Debug net472 run: 214/214 passed
